### PR TITLE
feat(explorer): add topic filtering and search highlighting

### DIFF
--- a/frontend/src/components/explorer/TopicTree.tsx
+++ b/frontend/src/components/explorer/TopicTree.tsx
@@ -1,4 +1,120 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, type ReactNode } from "react";
+
+interface HighlightTextProps {
+  name: string;
+  fullPath: string;
+  query: string;
+  isSelected?: boolean;
+}
+
+function HighlightText({
+  name,
+  fullPath,
+  query,
+  isSelected,
+}: HighlightTextProps): ReactNode {
+  const trimmed = query.trim();
+  if (!trimmed || trimmed === "+" || trimmed === "#" || trimmed === "*") {
+    return name;
+  }
+
+  const nodeStart = fullPath.length - name.length;
+  const nodeEnd = fullPath.length;
+
+  const lowerFullPath = fullPath.toLowerCase();
+  const lowerQuery = trimmed.toLowerCase();
+
+  // Find all match intervals [start, end] in fullPath
+  const intervals: [number, number][] = [];
+
+  // 1. Direct substring match on fullPath
+  let searchIdx = 0;
+  while (searchIdx <= lowerFullPath.length - lowerQuery.length) {
+    const idx = lowerFullPath.indexOf(lowerQuery, searchIdx);
+    if (idx === -1) break;
+    intervals.push([idx, idx + lowerQuery.length]);
+    searchIdx = idx + 1;
+  }
+
+  // 2. Also match individual tokens if query has path separators or wildcards
+  if (
+    lowerQuery.includes("/") ||
+    lowerQuery.includes("+") ||
+    lowerQuery.includes("#") ||
+    lowerQuery.includes("*")
+  ) {
+    const tokens = lowerQuery.split(/[/+#*]+/).filter((t) => t.length > 0);
+    for (const token of tokens) {
+      let tIdx = 0;
+      while (tIdx <= lowerFullPath.length - token.length) {
+        const found = lowerFullPath.indexOf(token, tIdx);
+        if (found === -1) break;
+        intervals.push([found, found + token.length]);
+        tIdx = found + 1;
+      }
+    }
+  }
+
+  // Intersect intervals with [nodeStart, nodeEnd] and convert to name-relative offsets
+  const nameIntervals: [number, number][] = [];
+  for (const [start, end] of intervals) {
+    const overlapStart = Math.max(start, nodeStart);
+    const overlapEnd = Math.min(end, nodeEnd);
+    if (overlapStart < overlapEnd) {
+      nameIntervals.push([overlapStart - nodeStart, overlapEnd - nodeStart]);
+    }
+  }
+
+  if (nameIntervals.length === 0) {
+    return name;
+  }
+
+  // Merge overlapping nameIntervals
+  nameIntervals.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const merged: [number, number][] = [];
+  for (const curr of nameIntervals) {
+    if (merged.length === 0) {
+      merged.push(curr);
+    } else {
+      const prev = merged[merged.length - 1];
+      if (curr[0] <= prev[1]) {
+        prev[1] = Math.max(prev[1], curr[1]);
+      } else {
+        merged.push(curr);
+      }
+    }
+  }
+
+  // Build the highlighted React nodes
+  const parts: ReactNode[] = [];
+  let lastIdx = 0;
+
+  for (let i = 0; i < merged.length; i++) {
+    const [start, end] = merged[i];
+    if (start > lastIdx) {
+      parts.push(name.slice(lastIdx, start));
+    }
+    parts.push(
+      <mark
+        key={i}
+        className={
+          isSelected
+            ? "bg-accent/40 text-primary-content font-bold px-0.5 rounded-xs"
+            : "bg-warning/25 text-warning font-bold px-0.5 rounded-xs"
+        }
+      >
+        {name.slice(start, end)}
+      </mark>,
+    );
+    lastIdx = end;
+  }
+
+  if (lastIdx < name.length) {
+    parts.push(name.slice(lastIdx));
+  }
+
+  return <>{parts}</>;
+}
 
 interface WSMessage {
   topic: string;
@@ -45,6 +161,8 @@ interface NodeProps {
   onDoubleClickTopic?: (topic: string) => void;
   depth: number;
   defaultExpanded: boolean;
+  filterText?: string;
+  expandCollapseVersion?: number;
 }
 
 function TreeNodeItem({
@@ -55,8 +173,11 @@ function TreeNodeItem({
   onDoubleClickTopic,
   depth,
   defaultExpanded,
+  filterText,
+  expandCollapseVersion,
 }: NodeProps) {
-  const [open, setOpen] = useState(defaultExpanded);
+  const isFiltered = Boolean(filterText?.trim());
+  const [open, setOpen] = useState(isFiltered || defaultExpanded);
   const hasChildren = node.children.size > 0;
   const isSelected = node.fullPath === selectedTopic;
   const isFlashing = flashTopics.has(node.fullPath);
@@ -74,7 +195,7 @@ function TreeNodeItem({
       >
         {hasChildren ? (
           <span
-            className="text-base-content/50 w-3 shrink-0 text-xl mb-1 "
+            className="text-base-content/50 w-3 shrink-0 text-xl mb-1"
             onClick={(e) => {
               e.stopPropagation();
               if (hasChildren) setOpen((o) => !o);
@@ -89,14 +210,19 @@ function TreeNodeItem({
         <span
           className={`font-mono truncate ${node.isLeaf && !hasChildren ? "text-accent" : ""}`}
         >
-          {node.name}
+          <HighlightText
+            name={node.name}
+            fullPath={node.fullPath}
+            query={filterText ?? ""}
+            isSelected={isSelected}
+          />
         </span>
       </div>
       {hasChildren && open && (
         <div>
           {Array.from(node.children.values()).map((child) => (
             <TreeNodeItem
-              key={child.fullPath}
+              key={`${child.fullPath}:${expandCollapseVersion ?? 0}:${filterText ?? ""}`}
               node={child}
               selectedTopic={selectedTopic}
               flashTopics={flashTopics}
@@ -104,6 +230,8 @@ function TreeNodeItem({
               onDoubleClickTopic={onDoubleClickTopic}
               depth={depth + 1}
               defaultExpanded={defaultExpanded}
+              filterText={filterText}
+              expandCollapseVersion={expandCollapseVersion}
             />
           ))}
         </div>
@@ -114,6 +242,9 @@ function TreeNodeItem({
 
 interface TopicTreeProps {
   topics: string[];
+  allTopicsCount?: number;
+  filterText?: string;
+  onClearFilter?: () => void;
   liveMessages: WSMessage[];
   selectedTopic: string | null;
   onSelectTopic: (topic: string) => void;
@@ -125,6 +256,9 @@ interface TopicTreeProps {
 
 export default function TopicTree({
   topics,
+  allTopicsCount,
+  filterText = "",
+  onClearFilter,
   liveMessages,
   selectedTopic,
   onSelectTopic,
@@ -162,7 +296,10 @@ export default function TopicTree({
     return () => clearTimeout(timer);
   }, [liveMessages]);
 
-  if (tree.size === 0) {
+  const isFiltered = Boolean(filterText.trim());
+  const totalCount = allTopicsCount ?? topics.length;
+
+  if (totalCount === 0) {
     return (
       <div className="flex items-center justify-center h-full text-base-content/40 text-sm p-4 text-center">
         No topics captured yet.
@@ -172,19 +309,38 @@ export default function TopicTree({
     );
   }
 
+  if (tree.size === 0 && isFiltered) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-base-content/50 text-xs p-4 text-center gap-2">
+        <span>No topics matching &ldquo;{filterText}&rdquo;</span>
+        {onClearFilter && (
+          <button
+            type="button"
+            className="btn btn-xs btn-outline btn-primary"
+            onClick={onClearFilter}
+          >
+            Clear filter
+          </button>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className="overflow-y-auto h-full py-1">
-      {/* Synthetic wildcard row: select all topics at once */}
-      <div
-        className={`flex items-center gap-1 mx-2 mb-1 px-2 py-1 rounded cursor-pointer select-none text-sm font-semibold transition-colors duration-300
-                    ${selectedTopic === "#" ? "bg-primary text-primary-content" : "bg-base-200 hover:bg-base-300"}`}
-        onClick={() => onSelectTopic("#")}
-      >
-        <span className="font-mono truncate"># (all topics)</span>
-      </div>
+      {/* Synthetic wildcard row: select all topics at once (only shown when not filtered) */}
+      {!isFiltered && (
+        <div
+          className={`flex items-center gap-1 mx-2 mb-1 px-2 py-1 rounded cursor-pointer select-none text-sm font-semibold transition-colors duration-300
+                      ${selectedTopic === "#" ? "bg-primary text-primary-content" : "bg-base-200 hover:bg-base-300"}`}
+          onClick={() => onSelectTopic("#")}
+        >
+          <span className="font-mono truncate"># (all topics)</span>
+        </div>
+      )}
       {Array.from(tree.values()).map((node) => (
         <TreeNodeItem
-          key={`${node.fullPath}:${expandCollapseVersion}`}
+          key={`${node.fullPath}:${expandCollapseVersion}:${filterText}`}
           node={node}
           selectedTopic={selectedTopic}
           flashTopics={flashTopics}
@@ -192,6 +348,8 @@ export default function TopicTree({
           onDoubleClickTopic={onDoubleClickTopic}
           depth={0}
           defaultExpanded={defaultExpanded}
+          filterText={filterText}
+          expandCollapseVersion={expandCollapseVersion}
         />
       ))}
     </div>

--- a/frontend/src/components/explorer/TopicTree.tsx
+++ b/frontend/src/components/explorer/TopicTree.tsx
@@ -179,7 +179,8 @@ function TreeNodeItem({
   const isFiltered = Boolean(filterText?.trim());
   const [open, setOpen] = useState(isFiltered || defaultExpanded);
   const hasChildren = node.children.size > 0;
-  const isSelected = node.fullPath === selectedTopic;
+  const isSelected =
+    node.fullPath === selectedTopic || `${node.fullPath}/#` === selectedTopic;
   const isFlashing = flashTopics.has(node.fullPath);
 
   return (

--- a/frontend/src/components/explorer/topicFilterUtils.ts
+++ b/frontend/src/components/explorer/topicFilterUtils.ts
@@ -1,0 +1,46 @@
+/**
+ * Checks whether an MQTT topic matches a given search/filter query.
+ *
+ * Matching rules:
+ * - Empty query matches everything.
+ * - Simple case-insensitive substring match on full topic path.
+ * - If query includes MQTT wildcards ('+' for single level, '#' for multi-level) or glob ('*'),
+ *   matches topic structure accordingly.
+ */
+export function topicMatchesFilter(topic: string, filter: string): boolean {
+  const q = filter.trim();
+  if (!q) return true;
+
+  const lowerTopic = topic.toLowerCase();
+  const lowerFilter = q.toLowerCase();
+
+  // Simple substring match first
+  if (lowerTopic.includes(lowerFilter)) {
+    return true;
+  }
+
+  // If query contains wildcards (+ or # or *)
+  if (q.includes("+") || q.includes("#") || q.includes("*")) {
+    try {
+      const escaped = lowerFilter
+        .replace(/[.+^${}()|[\]\\]/g, (char) => {
+          if (char === "+" || char === "^" || char === "$") {
+            return char === "+" ? "+" : `\\${char}`;
+          }
+          return `\\${char}`;
+        })
+        .replace(/\+/g, "[^/]+")
+        .replace(/#/g, ".*")
+        .replace(/\*/g, ".*");
+
+      const regex = new RegExp(`^${escaped}$`, "i");
+      if (regex.test(lowerTopic)) {
+        return true;
+      }
+    } catch {
+      // Fallback if regex creation fails
+    }
+  }
+
+  return false;
+}

--- a/frontend/src/pages/ExplorerPage.tsx
+++ b/frontend/src/pages/ExplorerPage.tsx
@@ -160,7 +160,11 @@ export default function ExplorerPage() {
     if (
       pickerCtx &&
       pickerSelectedTopic &&
-      displayedTopics.includes(pickerSelectedTopic)
+      (displayedTopics.includes(pickerSelectedTopic) ||
+        (pickerSelectedTopic.endsWith("/#") &&
+          displayedTopics.some((t) =>
+            t.startsWith(pickerSelectedTopic.slice(0, -1)),
+          )))
     ) {
       if (!pickerInitializedRef.current) {
         pickerInitializedRef.current = true;

--- a/frontend/src/pages/ExplorerPage.tsx
+++ b/frontend/src/pages/ExplorerPage.tsx
@@ -6,6 +6,7 @@ import { useWebSocket } from "../hooks/useWebSocket";
 import TopicTree from "../components/explorer/TopicTree";
 import LogPanel from "../components/panels/LogPanel";
 import ExplorerPublishPanel from "../components/explorer/ExplorerPublishPanel";
+import { topicMatchesFilter } from "../components/explorer/topicFilterUtils";
 
 interface WSMessage {
   topic: string;
@@ -66,6 +67,7 @@ export default function ExplorerPage() {
   const [cumulativeShow, setCumulativeShow] = useState(true);
   const [defaultExpanded, setDefaultExpanded] = useState(false);
   const [expandCollapseVersion, setExpandCollapseVersion] = useState(0);
+  const [filterText, setFilterText] = useState("");
   const pickerInitializedRef = useRef(false);
   const panelId = useId();
   const autoSelectedBrokerId = useMemo(() => {
@@ -118,6 +120,13 @@ export default function ExplorerPage() {
     for (const t of commonSysTopics) merged.add(t);
     return Array.from(merged).sort();
   }, [topics, showSysTopic, effectiveBrokerId]);
+
+  const filteredTopics = useMemo(() => {
+    if (!filterText.trim()) return displayedTopics;
+    return displayedTopics.filter((topic) =>
+      topicMatchesFilter(topic, filterText),
+    );
+  }, [displayedTopics, filterText]);
 
   // Subscribe to # on selected broker via WebSocket
   const { subscribe } = useWebSocket({
@@ -271,7 +280,9 @@ export default function ExplorerPage() {
           ))}
         </select>
         <span className="text-xs text-base-content/40">
-          {displayedTopics.length} topics captured
+          {filterText.trim()
+            ? `${filteredTopics.length} of ${displayedTopics.length} topics`
+            : `${displayedTopics.length} topics captured`}
         </span>
         <div className="ml-auto flex items-center gap-4">
           <label className="label cursor-pointer gap-2 p-0">
@@ -309,7 +320,7 @@ export default function ExplorerPage() {
       <div className="flex flex-col sm:flex-row flex-1 overflow-hidden">
         {/* Topic tree */}
         <aside className="w-full sm:w-72 shrink-0 max-h-64 sm:max-h-none border-b sm:border-b-0 sm:border-r border-base-300 bg-base-100 overflow-hidden flex flex-col">
-          <div className="px-3 py-2 border-b border-base-300 flex items-center justify-between gap-2">
+          <div className="px-3 py-2 border-b border-base-300 flex items-center justify-between gap-2 shrink-0">
             <span className="text-xs font-semibold text-base-content/50 uppercase tracking-wider">
               Topics
             </span>
@@ -334,16 +345,72 @@ export default function ExplorerPage() {
               </button>
             </div>
           </div>
-          <TopicTree
-            topics={displayedTopics}
-            liveMessages={liveMessages}
-            selectedTopic={selectedTopic}
-            onSelectTopic={handleTopicSelect}
-            onDoubleClickTopic={handlePickerDoubleClick}
-            showSysTopic={showSysTopic}
-            defaultExpanded={defaultExpanded}
-            expandCollapseVersion={expandCollapseVersion}
-          />
+
+          {/* Topic search / filter input */}
+          <div className="p-2 border-b border-base-300 shrink-0">
+            <div className="relative flex items-center">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-3.5 w-3.5 absolute left-2.5 text-base-content/40 pointer-events-none"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+              <input
+                type="text"
+                value={filterText}
+                onChange={(e) => setFilterText(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    setFilterText("");
+                  }
+                }}
+                placeholder="Filter topics..."
+                className="input input-sm input-bordered w-full pl-8 pr-7 text-xs font-mono"
+              />
+              {filterText && (
+                <button
+                  type="button"
+                  onClick={() => setFilterText("")}
+                  className="btn btn-ghost btn-xs btn-circle absolute right-1 h-5 w-5 min-h-0 text-base-content/50 hover:text-base-content"
+                  title="Clear filter (Esc)"
+                  aria-label="Clear filter"
+                >
+                  ✕
+                </button>
+              )}
+            </div>
+            {filterText && (
+              <div className="flex items-center justify-between mt-1 px-1 text-[11px] text-base-content/50">
+                <span>
+                  {filteredTopics.length} of {displayedTopics.length} matched
+                </span>
+                             </div>
+            )}
+          </div>
+
+          <div className="flex-1 overflow-hidden min-h-0 flex flex-col">
+            <TopicTree
+              topics={filteredTopics}
+              allTopicsCount={displayedTopics.length}
+              filterText={filterText}
+              onClearFilter={() => setFilterText("")}
+              liveMessages={liveMessages}
+              selectedTopic={selectedTopic}
+              onSelectTopic={handleTopicSelect}
+              onDoubleClickTopic={handlePickerDoubleClick}
+              showSysTopic={showSysTopic}
+              defaultExpanded={defaultExpanded}
+              expandCollapseVersion={expandCollapseVersion}
+            />
+          </div>
         </aside>
 
         {/* Detail panel */}

--- a/frontend/src/pages/ExplorerPage.tsx
+++ b/frontend/src/pages/ExplorerPage.tsx
@@ -64,7 +64,7 @@ export default function ExplorerPage() {
   );
   const [liveMessages, setLiveMessages] = useState<WSMessage[]>([]);
   const [showSysTopic, setShowSysTopic] = useState(false);
-  const [cumulativeShow, setCumulativeShow] = useState(true);
+  const [showExactTopicOnly, setShowExactTopicOnly] = useState(false);
   const [defaultExpanded, setDefaultExpanded] = useState(false);
   const [expandCollapseVersion, setExpandCollapseVersion] = useState(0);
   const [filterText, setFilterText] = useState("");
@@ -180,9 +180,35 @@ export default function ExplorerPage() {
     const isParent =
       !topic.endsWith("/#") &&
       displayedTopics.some((t) => t.startsWith(topic + "/"));
-    const effectiveTopic = cumulativeShow && isParent ? topic + "/#" : topic;
+    const effectiveTopic =
+      !showExactTopicOnly && isParent ? topic + "/#" : topic;
     setSelectedTopic(effectiveTopic);
     if (pickerCtx) setPickerSelectedTopic(effectiveTopic);
+  };
+
+  const handleToggleExactTopicOnly = (checked: boolean) => {
+    setShowExactTopicOnly(checked);
+    if (!selectedTopic || selectedTopic === "#") return;
+
+    if (checked) {
+      if (selectedTopic.endsWith("/#")) {
+        const stripped = selectedTopic.slice(0, -2);
+        setSelectedTopic(stripped);
+        if (pickerCtx) setPickerSelectedTopic(stripped);
+      }
+    } else {
+      const baseTopic = selectedTopic.endsWith("/#")
+        ? selectedTopic.slice(0, -2)
+        : selectedTopic;
+      const isParent = displayedTopics.some((t) =>
+        t.startsWith(baseTopic + "/"),
+      );
+      if (isParent) {
+        const subtreeTopic = `${baseTopic}/#`;
+        setSelectedTopic(subtreeTopic);
+        if (pickerCtx) setPickerSelectedTopic(subtreeTopic);
+      }
+    }
   };
 
   const handlePickerConfirm = () => {
@@ -292,15 +318,15 @@ export default function ExplorerPage() {
           <label className="label cursor-pointer gap-2 p-0">
             <div
               className="tooltip tooltip-left"
-              data-tip="When enabled, clicking a parent topic shows all messages from its child topics using a wildcard (topic/#)."
+              data-tip="When enabled, clicking a parent topic only shows messages published directly to that exact topic instead of including all child topics (topic/#)."
             >
-              <span className="label-text text-xs">Show subtree</span>
+              <span className="label-text text-xs">Show exact topic only</span>
             </div>
             <input
               type="checkbox"
               className="toggle toggle-xs toggle-secondary"
-              checked={cumulativeShow}
-              onChange={(e) => setCumulativeShow(e.target.checked)}
+              checked={showExactTopicOnly}
+              onChange={(e) => handleToggleExactTopicOnly(e.target.checked)}
             />
           </label>
           <label className="label cursor-pointer gap-2 p-0">

--- a/frontend/src/pages/ExplorerPage.tsx
+++ b/frontend/src/pages/ExplorerPage.tsx
@@ -418,11 +418,9 @@ export default function ExplorerPage() {
               )}
             </div>
             {filterText && (
-              <div className="flex items-center justify-between mt-1 px-1 text-[11px] text-base-content/50">
-                <span>
-                  {filteredTopics.length} of {displayedTopics.length} matched
-                </span>
-                             </div>
+              <div className="mt-1 px-1 text-[11px] text-base-content/50">
+                {filteredTopics.length} of {displayedTopics.length} matched
+              </div>
             )}
           </div>
 


### PR DESCRIPTION
## Summary
Adds a topic filtering feature to the **Explore** page to allow users to quickly search and find MQTT topics in large topic trees.

## Features & Changes
- **Filter Bar**: Added a search input above the topic tree with a search icon, quick clear button (`✕`), and <kbd>Esc</kbd> shortcut.
- **Match Stats**: Displays matched vs total topic counts in the header and filter bar.
- **Flexible Search Support**:
  - Case-insensitive substring matching.
  - Multi-level path queries (e.g. `test/counter` highlights both parent `test` and subtopic `counter`).
  - MQTT wildcards (`+` single-level, `#` multi-level) and glob (`*`).
- **Auto-Expansion**: When a filter is active, matching parent branches automatically expand so matched items are immediately visible.
- **Highlighting**: Matched characters and path segments are highlighted across tree levels.
- **Show exact topic only toggle**:
  - Replaces the old subtree toggle (disabled by default).
  - Dynamically updates active parent topic selection between exact topic and `/#` subtree wildcard.
- **Empty State**: Friendly empty state with a "Clear filter" action when no topics match.