### PR TITLE
feat(navbar): redesign navbar and dashboard selector

### DIFF
--- a/frontend/src/components/DashboardSelector.test.tsx
+++ b/frontend/src/components/DashboardSelector.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import DashboardSelector, { type Dashboard } from "./DashboardSelector";
 
@@ -7,71 +13,78 @@ const dashboards: Dashboard[] = [
   { id: "dash-2", name: "Second Dashboard", created_at: "2026-01-02" },
 ];
 
+function renderSelector(onSwitch = vi.fn()) {
+  render(
+    <DashboardSelector
+      dashboards={dashboards}
+      activeDashboardId="dash-1"
+      onSwitch={onSwitch}
+      onCreate={vi.fn()}
+      onRename={vi.fn()}
+      onDelete={vi.fn()}
+    />,
+  );
+  return onSwitch;
+}
+
 describe("DashboardSelector", () => {
   afterEach(() => {
     cleanup();
   });
 
-  it("hides the kebab menu when editMode is false", () => {
-    render(
-      <DashboardSelector
-        dashboards={dashboards}
-        activeDashboardId="dash-1"
-        editMode={false}
-        onSwitch={vi.fn()}
-        onCreate={vi.fn()}
-        onRename={vi.fn()}
-        onDelete={vi.fn()}
-      />,
-    );
+  it("lists dashboards and switches", () => {
+    const onSwitch = renderSelector();
+
+    fireEvent.click(screen.getByTitle("Dashboard options"));
+    const list = within(screen.getByRole("list", { name: "Dashboards" }));
 
     expect(
-      screen.getByRole("option", { name: "Default Dashboard" }),
+      list.getByRole("menuitem", { name: "Default Dashboard" }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("option", { name: "Second Dashboard" }),
-    ).toBeInTheDocument();
-    expect(screen.queryByTitle("Dashboard options")).not.toBeInTheDocument();
+
+    fireEvent.click(list.getByRole("menuitem", { name: "Second Dashboard" }));
+    expect(onSwitch).toHaveBeenCalledWith("dash-2");
   });
 
-  it("exposes create, import, rename, export, and delete via the kebab menu when editMode is true", () => {
-    render(
-      <DashboardSelector
-        dashboards={dashboards}
-        activeDashboardId="dash-1"
-        editMode={true}
-        onSwitch={vi.fn()}
-        onCreate={vi.fn()}
-        onRename={vi.fn()}
-        onDelete={vi.fn()}
-      />,
-    );
+  it("always exposes new, import, rename, export, duplicate and delete", () => {
+    renderSelector();
+
+    fireEvent.click(screen.getByTitle("Dashboard options"));
 
     expect(
-      screen.getByRole("option", { name: "Default Dashboard" }),
+      screen.getByRole("menuitem", { name: /New dashboard/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("option", { name: "Second Dashboard" }),
+      screen.getByRole("menuitem", { name: /Import from file/i }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /Rename/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /Export/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /Duplicate/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /Delete/i }),
+    ).toBeInTheDocument();
+  });
 
-    const kebab = screen.getByTitle("Dashboard options");
-    expect(kebab).toBeInTheDocument();
-    fireEvent.click(kebab);
+  it("filters the dashboard list by the search query", () => {
+    renderSelector();
 
+    fireEvent.click(screen.getByTitle("Dashboard options"));
+    fireEvent.change(screen.getByPlaceholderText("Find a dashboard"), {
+      target: { value: "second" },
+    });
+
+    const list = within(screen.getByRole("list", { name: "Dashboards" }));
     expect(
-      screen.getByRole("button", { name: /Create new/i }),
+      list.getByRole("menuitem", { name: "Second Dashboard" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /Import from JSON/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /Rename/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /Export/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /Delete/i }),
-    ).toBeInTheDocument();
+      list.queryByRole("menuitem", { name: "Default Dashboard" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/DashboardSelector.tsx
+++ b/frontend/src/components/DashboardSelector.tsx
@@ -1,7 +1,12 @@
 import { useRef, useState, useEffect } from "react";
+import { MdSearch } from "react-icons/md";
 import { api } from "../api/client";
 import type { Panel } from "../pages/DashboardPage";
-import { exportDashboard, parseDashboardImport } from "../utils/dashboardIO";
+import {
+  buildDashboardExport,
+  exportDashboard,
+  parseDashboardImport,
+} from "../utils/dashboardIO";
 import {
   DASHBOARD_TEMPLATES,
   templateToImportPayload,
@@ -17,7 +22,6 @@ export interface Dashboard {
 interface Props {
   dashboards: Dashboard[];
   activeDashboardId: string;
-  editMode: boolean;
   onSwitch: (id: string) => void;
   onCreate: (d: Dashboard) => void;
   onRename: (d: Dashboard) => void;
@@ -27,7 +31,6 @@ interface Props {
 export default function DashboardSelector({
   dashboards,
   activeDashboardId,
-  editMode,
   onSwitch,
   onCreate,
   onRename,
@@ -41,7 +44,9 @@ export default function DashboardSelector({
   const [createValue, setCreateValue] = useState("");
   const [busy, setBusy] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
   const menuRef = useRef<HTMLDivElement>(null);
+  const menuTriggerRef = useRef<HTMLButtonElement>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
   const createInputRef = useRef<HTMLInputElement>(null);
   const importInputRef = useRef<HTMLInputElement>(null);
@@ -73,9 +78,44 @@ export default function DashboardSelector({
 
   const activeDashboard = dashboards.find((d) => d.id === activeDashboardId);
 
-  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const val = e.target.value;
-    if (val !== activeDashboardId) onSwitch(val);
+  const q = query.trim().toLowerCase();
+  const visibleDashboards = q
+    ? dashboards.filter((d) => d.name.toLowerCase().includes(q))
+    : dashboards;
+
+  const openMenu = () => {
+    setQuery("");
+    setMenuOpen((o) => !o);
+  };
+
+  const closeMenu = () => {
+    setMenuOpen(false);
+    menuTriggerRef.current?.focus();
+  };
+
+  const pick = (id: string) => {
+    closeMenu();
+    if (id !== activeDashboardId) onSwitch(id);
+  };
+
+  const handleDuplicate = async () => {
+    if (!activeDashboard || busy) return;
+    setMenuOpen(false);
+    setBusy(true);
+    try {
+      const panels = await api.get<Panel[]>(
+        `/api/layouts?dashboard_id=${activeDashboardId}`,
+      );
+      const envelope = buildDashboardExport(
+        `${activeDashboard.name} copy`,
+        panels,
+      );
+      const d = await api.post<Dashboard>("/api/dashboards/import", envelope);
+      onCreate(d);
+    } catch (error) {
+      void error;
+    }
+    setBusy(false);
   };
 
   const openCreate = () => {
@@ -195,19 +235,34 @@ export default function DashboardSelector({
 
   return (
     <>
-      <div className="flex items-center gap-1">
-        {/* Dashboard select */}
-        <select
-          className="select select-sm"
-          value={activeDashboardId}
-          onChange={handleSelectChange}
+      <div
+        className="relative min-w-0"
+        ref={menuRef}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") closeMenu();
+        }}
+      >
+        <button
+          ref={menuTriggerRef}
+          className={`h-8 max-w-full flex items-center gap-2 pl-3 pr-2 rounded-lg border text-[12.5px] font-medium transition-colors ${
+            menuOpen
+              ? "bg-base-300 border-base-content/20"
+              : "bg-base-200 border-base-300 hover:bg-base-300"
+          }`}
+          onClick={openMenu}
+          title="Dashboard options"
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
         >
-          {dashboards.map((d) => (
-            <option key={d.id} value={d.id}>
-              {d.name}
-            </option>
-          ))}
-        </select>
+          <span className="truncate max-w-[6rem] sm:max-w-[10rem]">
+            {activeDashboard?.name ?? "No dashboard"}
+          </span>
+          <span
+            aria-hidden="true"
+            className="w-0 h-0 shrink-0 border-x-[3.5px] border-x-transparent border-t-4 border-t-base-content/50"
+          />
+        </button>
+
         <input
           ref={importInputRef}
           type="file"
@@ -216,75 +271,156 @@ export default function DashboardSelector({
           onChange={handleImportFile}
         />
 
-        {/* Kebab menu — only in edit mode */}
-        {editMode && (
-          <div className="relative" ref={menuRef}>
-            <button
-              className="btn btn-sm btn-ghost btn-square"
-              onClick={() => setMenuOpen((o) => !o)}
-              title="Dashboard options"
+        {menuOpen && (
+          <div
+            role="menu"
+            aria-label="Dashboard options"
+            className="fixed inset-x-2 top-[4.25rem] sm:absolute sm:inset-x-auto sm:left-0 sm:top-full sm:mt-1 sm:w-72 z-50 bg-base-100 border border-base-300 rounded-box shadow-lg"
+          >
+            <div className="p-2 pb-1">
+              <label className="input input-sm w-full">
+                <MdSearch className="text-base opacity-50" />
+                <input
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && visibleDashboards[0]) {
+                      pick(visibleDashboards[0].id);
+                    }
+                  }}
+                  placeholder="Find a dashboard"
+                />
+              </label>
+            </div>
+
+            <ul
+              aria-label="Dashboards"
+              className="menu w-full p-2 max-h-64 flex-nowrap overflow-y-auto"
             >
-              ⋮
-            </button>
-            {menuOpen && (
-              <ul className="absolute top-full right-0 mt-1 bg-base-100 border border-base-300 rounded-box z-50 w-44 p-1 shadow">
-                <li>
-                  <button
-                    className="w-full text-left px-3 py-2 hover:bg-base-200 rounded text-sm"
-                    onClick={openCreate}
-                  >
-                    Create new
-                  </button>
+              {dashboards.length === 0 ? (
+                <li className="px-2 py-1 text-xs text-base-content/50">
+                  No dashboards yet
                 </li>
-                <li>
-                  <button
-                    className="w-full text-left px-3 py-2 hover:bg-base-200 rounded text-sm"
-                    onClick={openImport}
-                  >
-                    Import from JSON
-                  </button>
+              ) : visibleDashboards.length === 0 ? (
+                <li className="px-2 py-1 text-xs text-base-content/50">
+                  No dashboard matches “{query}”
                 </li>
-                {activeDashboard && (
-                  <>
-                    <li
-                      aria-hidden="true"
-                      className="my-1 border-t border-base-300"
-                    />
-                    <li>
+              ) : (
+                visibleDashboards.map((d) => {
+                  const active = d.id === activeDashboardId;
+                  return (
+                    <li key={d.id} className="w-full min-w-0">
                       <button
-                        className="w-full text-left px-3 py-2 hover:bg-base-200 rounded text-sm"
-                        onClick={() => {
-                          setRenameValue(activeDashboard.name);
-                          setRenameOpen(true);
-                          setMenuOpen(false);
-                        }}
+                        role="menuitem"
+                        className={`!flex w-full min-w-0 items-center gap-2 ${active ? "menu-active" : ""}`}
+                        onClick={() => pick(d.id)}
                       >
-                        Rename
+                        <span
+                          className={`w-2 h-2 rounded-full shrink-0 ${
+                            active ? "bg-success" : "bg-base-content/25"
+                          }`}
+                        />
+                        <span className="min-w-0 flex-1 truncate text-left">
+                          {d.name}
+                        </span>
                       </button>
                     </li>
-                    <li>
-                      <button
-                        className="w-full text-left px-3 py-2 hover:bg-base-200 rounded text-sm"
-                        onClick={handleExport}
-                      >
-                        Export
-                      </button>
-                    </li>
-                    <li>
-                      <button
-                        className="w-full text-left px-3 py-2 hover:bg-base-200 rounded text-sm text-error"
-                        onClick={() => {
-                          setDeleteOpen(true);
-                          setMenuOpen(false);
-                        }}
-                        disabled={dashboards.length <= 1}
-                      >
-                        Delete
-                      </button>
-                    </li>
-                  </>
-                )}
-              </ul>
+                  );
+                })
+              )}
+            </ul>
+
+            <div className="border-t border-base-300" />
+            <ul className="menu w-full p-2">
+              <li>
+                <button role="menuitem" onClick={openCreate}>
+                  New dashboard
+                </button>
+              </li>
+              <li className="w-full min-w-0">
+                <button
+                  role="menuitem"
+                  className="!flex w-full min-w-0 items-center justify-between"
+                  onClick={openImport}
+                >
+                  <span>Import from file…</span>
+                  <span className="text-xs text-base-content/40 shrink-0">
+                    .json
+                  </span>
+                </button>
+              </li>
+              {activeDashboard && (
+                <>
+                  <li>
+                    <button
+                      role="menuitem"
+                      onClick={() => {
+                        setRenameValue(activeDashboard.name);
+                        setRenameOpen(true);
+                        setMenuOpen(false);
+                      }}
+                    >
+                      Rename
+                    </button>
+                  </li>
+                  <li className="w-full min-w-0">
+                    <button
+                      role="menuitem"
+                      className="!flex w-full min-w-0 items-center justify-between gap-2"
+                      onClick={handleExport}
+                    >
+                      <span className="min-w-0 flex-1 truncate text-left">
+                        Export “{activeDashboard.name}”
+                      </span>
+                      <span className="text-xs text-base-content/40 shrink-0">
+                        .json
+                      </span>
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      role="menuitem"
+                      onClick={handleDuplicate}
+                      disabled={busy}
+                    >
+                      Duplicate
+                    </button>
+                  </li>
+                </>
+              )}
+            </ul>
+            {activeDashboard && (
+              <div className="border-t border-base-300">
+                <ul className="menu w-full p-2">
+                  <li
+                    className="w-full min-w-0"
+                    title={
+                      dashboards.length <= 1
+                        ? "You need at least one dashboard — create another before deleting this one"
+                        : undefined
+                    }
+                  >
+                    <button
+                      role="menuitem"
+                      className="!flex w-full min-w-0 items-center text-error"
+                      onClick={() => {
+                        setDeleteOpen(true);
+                        setMenuOpen(false);
+                      }}
+                      disabled={dashboards.length <= 1}
+                    >
+                      <span className="min-w-0 flex-1 truncate text-left">
+                        Delete “{activeDashboard.name}”…
+                      </span>
+                      {dashboards.length <= 1 && (
+                        <span className="text-xs text-base-content/40 shrink-0">
+                          Last one
+                        </span>
+                      )}
+                    </button>
+                  </li>
+                </ul>
+              </div>
             )}
           </div>
         )}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,16 +1,15 @@
 import { useEffect, useRef, useState } from "react";
 import { NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
-import {
-  MdMenu,
-  MdEdit,
-  MdAdd,
-  MdKeyboardArrowUp,
-  MdKeyboardArrowDown,
-} from "react-icons/md";
+import { MdMenu, MdEdit, MdAdd, MdKeyboardArrowUp } from "react-icons/md";
 import DashboardSelector, { type Dashboard } from "./DashboardSelector";
 import { useBrokerStatuses, type BrokerStatus } from "../hooks/useBrokers";
 const worktreeModules = import.meta.glob<{
-  default: { worktree?: string; branch?: string; commit?: string; message?: string };
+  default: {
+    worktree?: string;
+    branch?: string;
+    commit?: string;
+    message?: string;
+  };
 }>("../worktreeInfo.json", { eager: true });
 const worktreeInfo = worktreeModules["../worktreeInfo.json"]?.default ?? null;
 
@@ -36,11 +35,28 @@ const NAV_LINKS = [
   { to: "/config", label: "Configuration" },
 ];
 
-const aggDotColor: Record<AggregatedStatus, string> = {
-  CONNECTED: "bg-success",
-  "PARTIALLY CONNECTED": "bg-warning",
-  DISCONNECTED: "bg-error",
+/** Chip surface for the aggregated broker state, per the Claude Design mock. */
+const aggChipClass: Record<AggregatedStatus, string> = {
+  CONNECTED: "bg-base-200 border-base-300 hover:bg-base-300",
+  "PARTIALLY CONNECTED": "bg-warning/10 border-warning/40 hover:bg-warning/20",
+  DISCONNECTED: "bg-error/10 border-error/40 hover:bg-error/20",
 };
+
+const aggTextClass: Record<AggregatedStatus, string> = {
+  CONNECTED: "text-base-content/70",
+  "PARTIALLY CONNECTED": "text-warning",
+  DISCONNECTED: "text-error",
+};
+
+/** Short summary of how many enabled brokers are currently connected. */
+function brokerSummary(statuses: BrokerStatus[]): string {
+  const enabled = statuses.filter((s) => s.is_enabled);
+  if (enabled.length === 0) return "No brokers";
+  const connected = enabled.filter((s) => s.status === "CONNECTED").length;
+  if (connected === enabled.length) return "All connected";
+  if (connected === 0) return "All brokers offline";
+  return `${connected} of ${enabled.length} connected`;
+}
 
 const statusDot: Record<string, string> = {
   CONNECTED: "bg-success",
@@ -66,7 +82,10 @@ export default function Layout() {
   const [backendReady, setBackendReady] = useState(false);
   const [flyoutOpen, setFlyoutOpen] = useState(false);
   const flyoutRef = useRef<HTMLDivElement>(null);
+  const flyoutTriggerRef = useRef<HTMLButtonElement>(null);
   const healthRetryRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const peekTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onDashboard = location.pathname === "/dashboard";
 
   // Health check with retry until backend responds
   useEffect(() => {
@@ -98,6 +117,39 @@ export default function Layout() {
     return () => document.removeEventListener("mousedown", handler);
   }, []);
 
+  // Navbar keyboard shortcuts: ⌘K/Ctrl+K opens the panel library, F hides the
+  // bar, Esc closes the broker flyout.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const el = e.target as HTMLElement | null;
+      const typing =
+        el?.tagName === "INPUT" ||
+        el?.tagName === "TEXTAREA" ||
+        el?.tagName === "SELECT" ||
+        el?.isContentEditable === true;
+
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        if (!onDashboard || !editMode) return;
+        e.preventDefault();
+        setFlyoutOpen(false);
+        setPanelLibraryOpen((o) => !o);
+        return;
+      }
+      if (e.key === "Escape") {
+        setFlyoutOpen(false);
+        return;
+      }
+      if (typing) return;
+      if (e.key.toLowerCase() === "f" && onDashboard) {
+        e.preventDefault();
+        setFlyoutOpen(false);
+        setNavHidden((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onDashboard, editMode]);
+
   useEffect(() => {
     if (!backendReady) return;
     api
@@ -116,7 +168,11 @@ export default function Layout() {
 
   const switchDashboard = (id: string) => {
     setActiveDashboardId(id);
-    localStorage.setItem(ACTIVE_DASHBOARD_KEY, id);
+    if (id) {
+      localStorage.setItem(ACTIVE_DASHBOARD_KEY, id);
+    } else {
+      localStorage.removeItem(ACTIVE_DASHBOARD_KEY);
+    }
   };
 
   const handleCreate = (d: Dashboard) => {
@@ -131,272 +187,439 @@ export default function Layout() {
   const handleDelete = (id: string) => {
     setDashboards((prev) => {
       const remaining = prev.filter((d) => d.id !== id);
-      if (remaining.length > 0) switchDashboard(remaining[0].id);
+      switchDashboard(remaining[0]?.id ?? "");
       return remaining;
     });
   };
 
-  const showDashboardControls = location.pathname === "/dashboard";
+  const showDashboardControls = onDashboard;
   const aggStatus = computeAggregated(brokerStatuses);
+  const barHidden = navHidden && showDashboardControls;
+  const visibleBrokers = brokerStatuses.slice(0, 6);
 
   return (
     <div className="min-h-screen flex flex-col">
-      <div className="sticky top-0 z-40 relative">
-        <nav
-          className={`navbar bg-base-100 border-b border-base-300 px-4 gap-2 ${navHidden && showDashboardControls ? "hidden" : ""}`}
-        >
-        <img
-          src="/logo.svg"
-          alt="mqtt-dashboard"
-          className="h-8 w-auto mx-2 cursor-pointer hover:opacity-80 transition-opacity"
-          onClick={() => setShowCredits(!showCredits)}
-        />
-        {showCredits && (
-          <div className="modal modal-open">
-            <div className="modal-box max-w-sm">
-              <div className="flex items-center gap-3 mb-4">
-                <img
-                  src="/logo.svg"
-                  alt="mqtt-dashboard"
-                  className="h-8 w-auto"
-                />
-                <div>
-                  <h3 className="font-bold text-lg leading-tight">
-                    MQTT Dashboard
-                  </h3>
-                  <p className="text-xs text-base-content/60">
-                    Version {packageJson.version}
-                  </p>
-                </div>
-              </div>
-
+      {showCredits && (
+        <div className="modal modal-open">
+          <div className="modal-box max-w-sm">
+            <div className="flex items-center gap-3 mb-4">
+              <img
+                src="/logo.svg"
+                alt="mqtt-dashboard"
+                className="h-8 w-auto"
+              />
               <div>
-                <p className="mb-2">
-                  This project was made by{" "}
-                  <a
-                    href="https://github.com/jmischler72"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="link font-semibold"
-                  >
-                    @jmischler72
-                  </a>{" "}
-                  and is open source on{" "}
-                  <a
-                    href="https://github.com/jmischler72/mqtt-dashboard"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="link"
-                  >
-                    GitHub
-                  </a>
-                  .
+                <h3 className="font-bold text-lg leading-tight">
+                  MQTT Dashboard
+                </h3>
+                <p className="text-xs text-base-content/60">
+                  Version {packageJson.version}
                 </p>
-                <p className="mb-2 text-base-content/70">
-                  Thanks for checking it out!
-                </p>
-              </div>
-
-              {/* Worktree info in dev environment */}
-              {import.meta.env.DEV && worktreeInfo && (
-                <div className="mt-4 pt-3 border-t border-base-300">
-                  <div className="text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-2">
-                    Development Worktree
-                  </div>
-                  <div className="bg-base-200 rounded-lg p-2.5 space-y-1.5 text-xs font-mono">
-                    <div className="flex justify-between items-center">
-                      <span className="text-base-content/60 font-sans">
-                        Worktree:
-                      </span>
-                      <span className="badge badge-sm badge-primary font-mono">
-                        {worktreeInfo.worktree}
-                      </span>
-                    </div>
-                    <div className="flex justify-between items-center">
-                      <span className="text-base-content/60 font-sans">
-                        Branch:
-                      </span>
-                      <span className="text-base-content/90">
-                        {worktreeInfo.branch}
-                      </span>
-                    </div>
-                    <div className="flex justify-between items-center">
-                      <span className="text-base-content/60 font-sans">
-                        Commit:
-                      </span>
-                      <span className="bg-base-300 px-1.5 py-0.5 rounded text-base-content/90">
-                        {worktreeInfo.commit}
-                      </span>
-                    </div>
-                    {worktreeInfo.message && (
-                      <div className="flex flex-col gap-0.5 pt-1.5 border-t border-base-300">
-                        <span className="text-base-content/60 font-sans">
-                          Last Commit:
-                        </span>
-                        <span
-                          className="text-[11px] text-base-content/80 truncate font-sans"
-                          title={worktreeInfo.message}
-                        >
-                          {worktreeInfo.message}
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
-
-              <div className="modal-action">
-                <button
-                  className="btn btn-sm btn-ghost"
-                  onClick={() => setShowCredits(false)}
-                >
-                  Ok
-                </button>
               </div>
             </div>
-            <div
-              className="modal-backdrop"
-              onClick={() => setShowCredits(false)}
-            />
-          </div>
-        )}
-        {/* Mobile: nav links collapse into a hamburger dropdown */}
-        <div className="dropdown sm:hidden">
-          <button
-            tabIndex={0}
-            className="btn btn-sm btn-ghost"
-            aria-label="Open navigation menu"
-          >
-            <MdMenu className="text-xl" />
-          </button>
-          <ul
-            tabIndex={0}
-            className="dropdown-content menu bg-base-100 border border-base-300 rounded-box z-50 mt-1 w-44 p-2 shadow"
-          >
-            {NAV_LINKS.map((link) => (
-              <li key={link.to}>
-                <NavLink
-                  to={link.to}
-                  className={({ isActive }) => (isActive ? "active" : "")}
-                >
-                  {link.label}
-                </NavLink>
-              </li>
-            ))}
-          </ul>
-        </div>
-        {/* Desktop: inline nav links */}
-        <div className="hidden sm:flex items-center gap-2">
-          {NAV_LINKS.map((link) => (
-            <NavLink
-              key={link.to}
-              to={link.to}
-              className={({ isActive }) =>
-                `btn btn-sm btn-ghost ${isActive ? "btn-active" : ""}`
-              }
-            >
-              {link.label}
-            </NavLink>
-          ))}
-        </div>
-        <div className="ml-auto flex items-center gap-2 min-w-0">
-          {showDashboardControls && dashboards.length > 0 && (
-            <DashboardSelector
-              dashboards={dashboards}
-              activeDashboardId={activeDashboardId}
-              editMode={editMode}
-              onSwitch={switchDashboard}
-              onCreate={handleCreate}
-              onRename={handleRename}
-              onDelete={handleDelete}
-            />
-          )}
-          {showDashboardControls && (
-            <>
-              <div
-                aria-hidden="true"
-                className="h-6 w-px bg-base-300 mx-1"
-              />
-              {editMode && (
-                <button
-                  className="btn btn-sm btn-primary gap-1.5"
-                  onClick={() => setPanelLibraryOpen(true)}
-                  title="Add panel"
-                >
-                  <MdAdd className="text-base" />
-                  <span className="hidden sm:inline">Add panel</span>
-                </button>
-              )}
-              <button
-                className={`btn btn-sm gap-1.5 ${editMode ? "btn-warning" : "btn-outline"}`}
-                onClick={() => setEditMode((prev) => !prev)}
-              >
-                <MdEdit className="text-base" />
-                {editMode ? "Edit: ON" : "Edit: OFF"}
-              </button>
-            </>
-          )}
 
-          {/* Aggregated broker status with flyout */}
-          <div className="relative" ref={flyoutRef}>
-            <button
-              className="flex items-center gap-2 btn btn-sm btn-ghost"
-              onClick={() => setFlyoutOpen((o) => !o)}
-            >
-              <span
-                className={`w-2.5 h-2.5 rounded-full shrink-0 ${aggDotColor[aggStatus]}`}
-              />
-              <span className="text-xs text-base-content/60 hidden sm:inline">
-                {aggStatus}
-              </span>
-            </button>
+            <div>
+              <p className="mb-2">
+                This project was made by{" "}
+                <a
+                  href="https://github.com/jmischler72"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="link font-semibold"
+                >
+                  @jmischler72
+                </a>{" "}
+                and is open source on{" "}
+                <a
+                  href="https://github.com/jmischler72/mqtt-dashboard"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="link"
+                >
+                  GitHub
+                </a>
+                .
+              </p>
+              <p className="mb-2 text-base-content/70">
+                Thanks for checking it out!
+              </p>
+            </div>
 
-            {flyoutOpen && (
-              <div className="absolute right-0 top-full mt-1 z-50 bg-base-100 border border-base-300 rounded-box shadow-lg w-56 p-2">
-                {brokerStatuses.length === 0 ? (
-                  <p className="text-xs text-base-content/50 px-2 py-1">
-                    No brokers configured
-                  </p>
-                ) : (
-                  brokerStatuses.map((bs) => (
-                    <button
-                      key={bs.id}
-                      className="w-full text-left flex items-center gap-2 px-2 py-1.5 rounded hover:bg-base-200 cursor-pointer"
-                      onClick={() => {
-                        navigate(`/config?broker=${encodeURIComponent(bs.id)}`);
-                        setFlyoutOpen(false);
-                      }}
-                    >
-                      <span
-                        className={`w-2 h-2 rounded-full shrink-0 ${statusDot[bs.status] ?? "bg-neutral"}`}
-                      />
-                      <span className="text-sm flex-1 truncate">{bs.name}</span>
-                      <span className="text-xs text-base-content/50">
-                        {bs.status}
+            {/* Worktree info in dev environment */}
+            {import.meta.env.DEV && worktreeInfo && (
+              <div className="mt-4 pt-3 border-t border-base-300">
+                <div className="text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-2">
+                  Development Worktree
+                </div>
+                <div className="bg-base-200 rounded-lg p-2.5 space-y-1.5 text-xs font-mono">
+                  <div className="flex justify-between items-center">
+                    <span className="text-base-content/60 font-sans">
+                      Worktree:
+                    </span>
+                    <span className="badge badge-sm badge-primary font-mono">
+                      {worktreeInfo.worktree}
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center">
+                    <span className="text-base-content/60 font-sans">
+                      Branch:
+                    </span>
+                    <span className="text-base-content/90">
+                      {worktreeInfo.branch}
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center">
+                    <span className="text-base-content/60 font-sans">
+                      Commit:
+                    </span>
+                    <span className="bg-base-300 px-1.5 py-0.5 rounded text-base-content/90">
+                      {worktreeInfo.commit}
+                    </span>
+                  </div>
+                  {worktreeInfo.message && (
+                    <div className="flex flex-col gap-0.5 pt-1.5 border-t border-base-300">
+                      <span className="text-base-content/60 font-sans">
+                        Last Commit:
                       </span>
-                    </button>
-                  ))
-                )}
+                      <span
+                        className="text-[11px] text-base-content/80 truncate font-sans"
+                        title={worktreeInfo.message}
+                      >
+                        {worktreeInfo.message}
+                      </span>
+                    </div>
+                  )}
+                </div>
               </div>
             )}
+
+            <div className="modal-action">
+              <button
+                className="btn btn-sm btn-ghost"
+                onClick={() => setShowCredits(false)}
+              >
+                Ok
+              </button>
+            </div>
           </div>
+          <div
+            className="modal-backdrop"
+            onClick={() => setShowCredits(false)}
+          />
         </div>
-        </nav>
-        {showDashboardControls && (
+      )}
+      <div className="sticky top-0 z-40 relative">
+        {barHidden && (
+          /* Focus mode, per the Claude Design mock: the bar collapses to a thin
+             strip that keeps the edit accent and broker health visible. */
           <button
-            onClick={() => setNavHidden((v) => !v)}
-            title={navHidden ? "Show navbar" : "Hide navbar"}
-            aria-label={navHidden ? "Show navbar" : "Hide navbar"}
+            type="button"
+            onMouseEnter={() => {
+              peekTimerRef.current = setTimeout(() => setNavHidden(false), 260);
+            }}
+            onMouseLeave={() => {
+              if (peekTimerRef.current) clearTimeout(peekTimerRef.current);
+            }}
+            onClick={() => setNavHidden(false)}
+            title="Show navbar (F)"
+            aria-label="Show navbar"
+            className="group relative w-full h-2.5 flex items-center justify-between px-4 bg-base-200 border-b border-base-300"
+          >
+            {editMode && (
+              <span
+                aria-hidden="true"
+                className="absolute inset-x-0 top-0 h-0.5 bg-primary"
+              />
+            )}
+            <span className="h-[3px] w-6 rounded-full bg-base-content/20 transition-colors group-hover:bg-base-content/40" />
+            <span className="flex items-center gap-1">
+              {visibleBrokers.map((bs) => (
+                <span
+                  key={bs.id}
+                  className={`w-[5px] h-[5px] rounded-full ${statusDot[bs.status] ?? "bg-neutral"}`}
+                />
+              ))}
+            </span>
+          </button>
+        )}
+        <nav
+          className={`navbar bg-base-100 border-b border-base-300 px-4 gap-2 ${barHidden ? "hidden" : ""}`}
+        >
+          {editMode && (
+            <span
+              aria-hidden="true"
+              className="absolute inset-x-0 top-0 h-0.5 bg-primary"
+            />
+          )}
+          <img
+            src="/logo.svg"
+            alt="mqtt-dashboard"
+            className="h-8 w-auto mx-2 cursor-pointer hover:opacity-80 transition-opacity"
+            onClick={() => setShowCredits(!showCredits)}
+          />
+
+          {/* Mobile: nav links collapse into a hamburger dropdown */}
+          <div className="dropdown sm:hidden">
+            <button
+              tabIndex={0}
+              className="btn btn-sm btn-ghost"
+              aria-label="Open navigation menu"
+            >
+              <MdMenu className="text-xl" />
+            </button>
+            <ul
+              tabIndex={0}
+              className="dropdown-content menu bg-base-100 border border-base-300 rounded-box z-50 mt-1 w-44 p-2 shadow"
+            >
+              {NAV_LINKS.map((link) => (
+                <li key={link.to}>
+                  <NavLink
+                    to={link.to}
+                    className={({ isActive }) => (isActive ? "active" : "")}
+                  >
+                    {link.label}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Desktop: inline nav links */}
+          <div className="hidden sm:flex items-center gap-2">
+            {NAV_LINKS.map((link) => (
+              <NavLink
+                key={link.to}
+                to={link.to}
+                className={({ isActive }) =>
+                  `btn btn-sm btn-ghost ${isActive ? "btn-active" : ""}`
+                }
+              >
+                {link.label}
+              </NavLink>
+            ))}
+          </div>
+
+          <div className="ml-auto flex items-center gap-1 sm:gap-2 min-w-0">
+            {showDashboardControls && !dashboardsLoading && (
+              <DashboardSelector
+                dashboards={dashboards}
+                activeDashboardId={activeDashboardId}
+                onSwitch={switchDashboard}
+                onCreate={handleCreate}
+                onRename={handleRename}
+                onDelete={handleDelete}
+              />
+            )}
+
+            {showDashboardControls && (
+              <>
+                <div
+                  aria-hidden="true"
+                  className="hidden sm:block h-6 w-px bg-base-300 mx-1"
+                />
+                {editMode ? (
+                  <>
+                    <button
+                      className="btn btn-sm btn-primary gap-1.5"
+                      onClick={() => setPanelLibraryOpen(true)}
+                      title="Add panel (⌘K)"
+                    >
+                      <MdAdd className="text-base" />
+                      <span className="hidden sm:inline">Add panel</span>
+                      <kbd className="kbd kbd-xs hidden md:inline-flex">⌘K</kbd>
+                    </button>
+                    <button
+                      className="btn btn-sm btn-outline"
+                      onClick={() => {
+                        setEditMode(false);
+                        setPanelLibraryOpen(false);
+                      }}
+                    >
+                      Done
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    className="btn btn-sm btn-outline gap-1.5"
+                    onClick={() => setEditMode(true)}
+                  >
+                    <MdEdit className="text-base" />
+                    <span className="hidden sm:inline">Edit layout</span>
+                  </button>
+                )}
+              </>
+            )}
+
+            {/* Aggregated broker status with flyout */}
+            <div
+              aria-hidden="true"
+              className="hidden sm:block h-6 w-px bg-base-300 mx-1"
+            />
+            <div
+              className="relative shrink-0"
+              ref={flyoutRef}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  setFlyoutOpen(false);
+                  flyoutTriggerRef.current?.focus();
+                }
+              }}
+            >
+              <button
+                ref={flyoutTriggerRef}
+                className={`h-8 shrink-0 flex items-center gap-2 pl-2.5 pr-2 rounded-lg border transition-colors ${aggChipClass[aggStatus]} ${flyoutOpen ? "brightness-95" : ""}`}
+                onClick={() => setFlyoutOpen((o) => !o)}
+                title="Broker status"
+                aria-haspopup="menu"
+                aria-expanded={flyoutOpen}
+              >
+                <span className="flex items-center gap-[3px]">
+                  {visibleBrokers.length === 0 ? (
+                    <span className="w-[5px] h-3 rounded-[2px] bg-neutral" />
+                  ) : (
+                    visibleBrokers.map((bs, i) => (
+                      <span
+                        key={bs.id}
+                        className={`w-[5px] h-3 rounded-[2px] ${i >= 3 ? "hidden sm:block" : ""} ${statusDot[bs.status] ?? "bg-neutral"}`}
+                      />
+                    ))
+                  )}
+                  {brokerStatuses.length > visibleBrokers.length && (
+                    <span className="hidden sm:inline text-[10px] leading-none text-base-content/40 tabular-nums">
+                      +{brokerStatuses.length - visibleBrokers.length}
+                    </span>
+                  )}
+                </span>
+                <span
+                  className={`hidden sm:inline text-xs tabular-nums ${aggTextClass[aggStatus]}`}
+                >
+                  {brokerSummary(brokerStatuses)}
+                </span>
+                <span
+                  aria-hidden="true"
+                  className="w-0 h-0 border-x-[3.5px] border-x-transparent border-t-4 border-t-base-content/50"
+                />
+              </button>
+
+              {flyoutOpen && (
+                <div
+                  role="menu"
+                  aria-label="Broker status"
+                  className="absolute right-0 top-full mt-1 z-50 w-[min(18rem,calc(100vw-1rem))] bg-base-100 border border-base-300 rounded-box shadow-lg"
+                >
+                  <div className="flex items-center justify-between px-4 pt-3 pb-1">
+                    <span className="text-xs uppercase tracking-wider text-base-content/50">
+                      MQTT brokers
+                    </span>
+                    <span className="text-xs text-base-content/50">
+                      {brokerStatuses.length} configured
+                    </span>
+                  </div>
+
+                  {brokerStatuses.length === 0 ? (
+                    <p className="text-xs text-base-content/50 px-4 pb-3">
+                      No brokers configured
+                    </p>
+                  ) : (
+                    <ul className="menu w-full p-2">
+                      {brokerStatuses.map((bs) => (
+                        <li key={bs.id} className="w-full min-w-0">
+                          <button
+                            role="menuitem"
+                            className="!flex w-full min-w-0 items-center gap-2"
+                            onClick={() => {
+                              navigate(
+                                `/config?broker=${encodeURIComponent(bs.id)}`,
+                              );
+                              setFlyoutOpen(false);
+                              flyoutTriggerRef.current?.focus();
+                            }}
+                          >
+                            <span
+                              className={`w-2 h-2 rounded-full shrink-0 ${statusDot[bs.status] ?? "bg-neutral"}`}
+                            />
+                            <span className="flex flex-col min-w-0 flex-1">
+                              <span className="text-sm truncate">
+                                {bs.name}
+                              </span>
+                              <span className="text-xs text-base-content/50 truncate">
+                                {bs.status_error ??
+                                  (bs.is_enabled ? "Enabled" : "Disabled")}
+                              </span>
+                            </span>
+                            <span className="text-xs text-base-content/50 shrink-0">
+                              {bs.status}
+                            </span>
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+
+                  <div className="border-t border-base-300">
+                    <ul className="menu w-full p-2">
+                      <li className="w-full min-w-0">
+                        <button
+                          role="menuitem"
+                          className="!flex w-full min-w-0 items-center justify-between"
+                          onClick={() => {
+                            navigate("/config");
+                            setFlyoutOpen(false);
+                            flyoutTriggerRef.current?.focus();
+                          }}
+                        >
+                          <span className="text-sm">Manage brokers</span>
+                          <span className="text-xs text-base-content/40 shrink-0">
+                            Configuration
+                          </span>
+                        </button>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </nav>
+
+        {showDashboardControls && !barHidden && (
+          <button
+            onClick={() => setNavHidden(true)}
+            title="Hide navbar (F)"
+            aria-label="Hide navbar"
             className="absolute left-2 top-full flex items-center justify-center w-7 h-5 bg-base-100 border-l border-r border-b border-base-300 rounded-b-md text-base-content/60 hover:text-base-content"
           >
-            {navHidden ? (
-              <MdKeyboardArrowDown className="text-base" />
-            ) : (
-              <MdKeyboardArrowUp className="text-base" />
-            )}
+            <MdKeyboardArrowUp className="text-base" />
           </button>
         )}
       </div>
+
+      {/* Focus mode still needs the edit controls: float them over the grid. */}
+      {barHidden && editMode && (
+        <div className="fixed bottom-5 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 h-11 pl-3.5 pr-1.5 rounded-full bg-base-100 border border-base-300 shadow-xl">
+          <span className="flex items-center gap-2 pr-1">
+            <span className="w-1.5 h-1.5 rounded-full bg-primary" />
+            <span className="text-xs text-base-content/70">Editing</span>
+          </span>
+          <button
+            className="btn btn-sm btn-primary rounded-full gap-1.5"
+            onClick={() => setPanelLibraryOpen(true)}
+            title="Add panel (⌘K)"
+          >
+            <MdAdd className="text-base" />
+            Add panel
+          </button>
+          <button
+            className="btn btn-sm btn-outline rounded-full"
+            onClick={() => {
+              setEditMode(false);
+              setPanelLibraryOpen(false);
+            }}
+          >
+            Done
+          </button>
+        </div>
+      )}
       <main className="flex-1">
         {!backendReady ? (
           <div className="flex items-center justify-center h-64 text-base-content/60">
@@ -412,6 +635,7 @@ export default function Layout() {
               setEditMode,
               activeDashboardId,
               dashboardsLoading,
+              hasDashboards: dashboards.length > 0,
               brokerStatuses,
               panelLibraryOpen,
               setPanelLibraryOpen,

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -47,6 +47,7 @@ type LayoutContext = {
   setEditMode: React.Dispatch<React.SetStateAction<boolean>>;
   activeDashboardId: string;
   dashboardsLoading: boolean;
+  hasDashboards: boolean;
   brokerStatuses: BrokerStatus[];
   panelLibraryOpen: boolean;
   setPanelLibraryOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -94,6 +95,7 @@ export default function DashboardPage() {
     editMode,
     activeDashboardId,
     dashboardsLoading,
+    hasDashboards,
     brokerStatuses,
     panelLibraryOpen,
     setPanelLibraryOpen,
@@ -180,7 +182,6 @@ export default function DashboardPage() {
       static: !gridInteractionsEnabled,
     };
   });
-
 
   const handleLayoutChange = useCallback(
     (newLayout: GridLayout[]) => {
@@ -332,11 +333,21 @@ export default function DashboardPage() {
       <div className="min-h-screen bg-base-200">
         {/* Grid */}
         <div className="p-4" ref={containerRef}>
-          {dashboardsLoading || isLoadingLayout ? (
+          {dashboardsLoading || (hasDashboards && isLoadingLayout) ? (
             <div className="flex items-center justify-center h-64 text-base-content/60">
               <div className="text-center">
                 <span className="loading loading-spinner loading-lg mb-4" />
                 <p className="text-xl">Loading dashboard layout...</p>
+              </div>
+            </div>
+          ) : !hasDashboards ? (
+            <div className="flex items-center justify-center h-64 text-base-content/40">
+              <div className="text-center">
+                <p className="text-2xl mb-2">No dashboards yet</p>
+                <p>
+                  Open the dashboard selector in the navbar to create your first
+                  one
+                </p>
               </div>
             </div>
           ) : panels.length === 0 ? (


### PR DESCRIPTION
## Summary
- Redesigns the top navbar and dashboard selector following a Claude Design mock: pill nav tabs, a searchable dashboard dropdown, an aggregated broker-status chip with a flyout, and a focus mode that collapses the bar into a thin strip (`F` to toggle, hover to bring it back, `⌘K` to open the panel library while editing).
- Dashboard actions (New, Import, Rename, Export, Duplicate, Delete) are always visible in the dropdown now, no longer gated behind edit mode — edit mode is scoped purely to panel-layout mutation (drag/resize/add/remove), where accidental changes are an actual risk.
- Fixes: long broker names/error messages and dashboard names no longer overflow their dropdowns (daisyUI's `.menu` forces `display:grid` on list items, which silently defeated flex-based truncation); a fresh install with zero dashboards no longer gets stuck on an infinite loading spinner (added a proper "No dashboards yet" empty state); `⌘K` no longer silently flips the dashboard into edit mode as a side effect; broker dropdown/dashboard dropdown menus now use proper `role="menu"`/`role="menuitem"` markup with consistent Escape-to-close and focus return to the trigger.
- Backend already enforces "can't delete the last dashboard" (409) and seeds a default dashboard on init, so that guard is preserved in the UI (disabled Delete + explanatory tooltip) rather than relaxed.

## Test plan
- [x] `tsc -b --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run` — 68/68 passing
- [x] `npm run build` succeeds
- [ ] Manual check in a running dev stack (`make dev-start`) — not done in this session, worth a quick look before merge, especially the focus-mode hover/hide behavior and the dashboard dropdown on mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015H4MhXpiTtdwJo931Liw1f