### PR TITLE
fix(docker): wait for mosquitto healthcheck before starting dashboard

### DIFF
--- a/docker/doc/docker-compose.with-broker.yml
+++ b/docker/doc/docker-compose.with-broker.yml
@@ -11,7 +11,8 @@ services:
       - dashboard_data:/app/data
       - ./config.json:/app/config.json:ro
     depends_on:
-      - mosquitto
+      mosquitto:
+        condition: service_healthy
 
   mosquitto:
     image: eclipse-mosquitto:2
@@ -24,6 +25,12 @@ services:
       - ./mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
       - mosquitto_data:/mosquitto/data
       - mosquitto_log:/mosquitto/log
+    healthcheck:
+      test: ["CMD", "mosquitto_pub", "-h", "localhost", "-t", "healthcheck", "-m", "ping", "-q", "0"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
 
 volumes:
   dashboard_data:


### PR DESCRIPTION
## Summary
- Fixes `dial tcp: lookup mosquitto ... no such host` when using the all-in-one broker stack (`docker/doc/docker-compose.with-broker.yml`)
- Root cause: `mqtt-dashboard` only waited for the `mosquitto` container to *start*, not for the broker to actually accept connections, so its first MQTT connection attempt could race the broker startup
- Added a `healthcheck` to the `mosquitto` service and switched `mqtt-dashboard`'s `depends_on` to `condition: service_healthy`

## Test plan
- [x] `docker compose -f docker/doc/docker-compose.with-broker.yml up -d` — mosquitto reports `healthy`, dashboard starts after and connects with 0 errors in logs