### PR TITLE
feat(panels): add toggle panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ go build -o mqtt-dashboard .
 | **Gauge** | Real-time telemetry gauge (radial, bar, value) for numeric, boolean, or string data, with nested JSON path extraction |
 | **Button** | One-click publish a preset payload to a topic with QoS, Retain, and optional confirmation modal |
 | **Input** | Type and send ad-hoc messages to any topic with configurable QoS and Retain flags |
+| **Toggle** | Switch a device on/off and reflect its real state from a command or separate telemetry topic, with configurable on/off payloads |
 | **Log** | Real-time message stream with persistent history, wildcards, QoS/Retain badges, and date formatting |
 | **Cron** | Scheduled automatic publishing with visual cron builder helper, next-run countdown, and toggle switch |
 | **Stats** | Live broker statistics and message activity charts ($SYS telemetry, memory, client counts) |

--- a/frontend/src/components/panels/TogglePanel.tsx
+++ b/frontend/src/components/panels/TogglePanel.tsx
@@ -323,7 +323,7 @@ function ToggleRuntime({ panelId, brokerId, config }: TogglePanelProps) {
           Number.isNaN(parsed) ? Date.now() : parsed,
         );
       })
-      .catch(() => { });
+      .catch(() => {});
 
     return () => {
       cancelled = true;
@@ -472,11 +472,7 @@ function ToggleRuntime({ panelId, brokerId, config }: TogglePanelProps) {
     : "transform 200ms ease, background-color 200ms ease";
 
   const trackClass =
-    displayed === null
-      ? "bg-base-300"
-      : displayed
-        ? "bg-success"
-        : "bg-error";
+    displayed === null ? "bg-base-300" : displayed ? "bg-success" : "bg-error";
   const stateTextClass =
     displayed === null
       ? "text-base-content/50"

--- a/frontend/src/components/panels/TogglePanel.tsx
+++ b/frontend/src/components/panels/TogglePanel.tsx
@@ -1,0 +1,592 @@
+import { useState, useEffect, useRef } from "react";
+import { MdToggleOn } from "react-icons/md";
+import { RiErrorWarningLine, RiLoader4Line, RiTimeLine } from "react-icons/ri";
+import { useWebSocket } from "../../hooks/useWebSocket";
+import { api } from "../../api/client";
+import type { BrokerStatus } from "../../hooks/useBrokers";
+import BrokerTopicSection from "./BrokerTopicSection";
+import MqttOptionsSection from "./MqttOptionsSection";
+import PanelModalFrame from "./PanelModalFrame";
+import {
+  parseToggleState,
+  DEFAULT_ON_PAYLOAD,
+  DEFAULT_OFF_PAYLOAD,
+} from "./toggleUtils";
+
+/** How long to wait for the state topic to confirm a flip before giving up. */
+const CONFIRM_TIMEOUT_MS = 5000;
+
+export interface ToggleConfig {
+  /** Command topic — the toggle publishes here. */
+  topic?: string;
+  /** Optional state/telemetry topic. When empty, the command topic is used. */
+  stateTopic?: string;
+  onPayload?: string;
+  offPayload?: string;
+  /** Optional JSON key to read the state from. */
+  valueKey?: string;
+  qos?: number;
+  retain?: boolean;
+}
+
+interface ModalProps {
+  config: ToggleConfig;
+  brokerId: string;
+  brokerStatuses: BrokerStatus[];
+  onSave: (cfg: ToggleConfig, brokerId: string) => void;
+  onClose: () => void;
+  onPickTopic?: (data: {
+    currentTopic: string;
+    selectedBrokerId: string;
+    draftConfig?: ToggleConfig;
+  }) => void;
+  initialTopic?: string;
+  initialBrokerId?: string;
+}
+
+export function ToggleConfigModal({
+  config,
+  brokerId,
+  brokerStatuses,
+  onSave,
+  onClose,
+  onPickTopic,
+  initialTopic,
+  initialBrokerId,
+}: ModalProps) {
+  const defaultBrokerId =
+    brokerStatuses.find((b) => b.is_enabled)?.id ?? brokerStatuses[0]?.id ?? "";
+  const [topic, setTopic] = useState(initialTopic ?? config.topic ?? "");
+  const [separateStateTopic, setSeparateStateTopic] = useState(
+    Boolean(config.stateTopic?.trim()),
+  );
+  const [stateTopic, setStateTopic] = useState(config.stateTopic ?? "");
+  const [onPayload, setOnPayload] = useState(
+    config.onPayload ?? DEFAULT_ON_PAYLOAD,
+  );
+  const [offPayload, setOffPayload] = useState(
+    config.offPayload ?? DEFAULT_OFF_PAYLOAD,
+  );
+  const [valueKey, setValueKey] = useState(config.valueKey ?? "");
+  const [qos, setQos] = useState(config.qos ?? 0);
+  const [retain, setRetain] = useState(config.retain ?? false);
+  const [selectedBrokerId, setSelectedBrokerId] = useState(
+    initialBrokerId || brokerId || defaultBrokerId,
+  );
+
+  const hasWildcardWarning = topic.includes("+") || topic.includes("#");
+  const effectiveStateTopic = separateStateTopic ? stateTopic.trim() : "";
+
+  return (
+    <PanelModalFrame
+      title="Toggle Configuration"
+      icon={MdToggleOn}
+      onClose={onClose}
+      onSave={() =>
+        onSave(
+          {
+            topic,
+            stateTopic: effectiveStateTopic,
+            onPayload,
+            offPayload,
+            valueKey: valueKey.trim(),
+            qos,
+            retain,
+          },
+          selectedBrokerId,
+        )
+      }
+      saveDisabled={
+        brokerStatuses.length === 0 ||
+        !topic.trim() ||
+        hasWildcardWarning ||
+        !onPayload.trim() ||
+        !offPayload.trim()
+      }
+      maxWidthClass="max-w-lg"
+    >
+      <BrokerTopicSection
+        selectedBrokerId={selectedBrokerId}
+        onBrokerChange={setSelectedBrokerId}
+        brokerStatuses={brokerStatuses}
+        topic={topic}
+        onTopicChange={setTopic}
+        onPickTopic={
+          onPickTopic
+            ? () => onPickTopic({ currentTopic: topic, selectedBrokerId })
+            : undefined
+        }
+        topicLabel="Command topic"
+        allowWildcards={false}
+        allowMultiple={false}
+        helpText="The topic the toggle publishes to. Also used to read the state unless a separate state topic is set below."
+      />
+
+      <fieldset className="fieldset p-0 border-0">
+        <label className="flex items-center justify-between cursor-pointer p-2 rounded-lg border border-base-300 bg-base-200/40">
+          <span className="text-xs font-medium text-base-content/80">
+            State topic is different
+          </span>
+          <input
+            type="checkbox"
+            className="toggle toggle-xs toggle-primary"
+            checked={separateStateTopic}
+            onChange={(e) => setSeparateStateTopic(e.target.checked)}
+          />
+        </label>
+
+        {separateStateTopic && (
+          <div className="mt-2">
+            <legend className="fieldset-legend font-medium text-xs text-base-content/80 mb-1">
+              State topic
+            </legend>
+            <input
+              className={`input input-bordered input-sm w-full font-mono text-xs ${
+                !stateTopic.trim() ? "input-warning" : ""
+              }`}
+              value={stateTopic}
+              onChange={(e) => setStateTopic(e.target.value)}
+              placeholder="e.g. home/lamp/state"
+            />
+            <p className="text-[11px] text-base-content/60 mt-1.5 leading-normal">
+              The topic the device reports its actual state on. Read-only, so
+              wildcards are allowed here.
+            </p>
+          </div>
+        )}
+      </fieldset>
+
+      <fieldset className="fieldset p-0 border-0">
+        <legend className="fieldset-legend font-medium text-xs text-base-content/80 mb-1">
+          Payloads
+        </legend>
+        <div className="grid grid-cols-2 gap-2">
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] text-base-content/60">On</span>
+            <input
+              className={`input input-bordered input-sm w-full font-mono text-xs ${
+                !onPayload.trim() ? "input-warning" : ""
+              }`}
+              value={onPayload}
+              onChange={(e) => setOnPayload(e.target.value)}
+              placeholder={DEFAULT_ON_PAYLOAD}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] text-base-content/60">Off</span>
+            <input
+              className={`input input-bordered input-sm w-full font-mono text-xs ${
+                !offPayload.trim() ? "input-warning" : ""
+              }`}
+              value={offPayload}
+              onChange={(e) => setOffPayload(e.target.value)}
+              placeholder={DEFAULT_OFF_PAYLOAD}
+            />
+          </label>
+        </div>
+        <p className="text-[11px] text-base-content/60 mt-1.5 leading-normal">
+          Sent when the toggle is flipped, and matched against incoming messages
+          to read the state back.
+        </p>
+      </fieldset>
+
+      <fieldset className="fieldset p-0 border-0">
+        <legend className="fieldset-legend font-medium text-xs text-base-content/80 mb-1">
+          JSON key <span className="opacity-60 font-normal">(optional)</span>
+        </legend>
+        <input
+          className="input input-bordered input-sm w-full font-mono text-xs"
+          value={valueKey}
+          onChange={(e) => setValueKey(e.target.value)}
+          placeholder="e.g. state"
+        />
+        <p className="text-[11px] text-base-content/60 mt-1.5 leading-normal">
+          Read the state from this key when the device publishes JSON, e.g.{" "}
+          <code className="font-mono">{`{"state":"ON"}`}</code>.
+        </p>
+      </fieldset>
+
+      <MqttOptionsSection
+        qos={qos}
+        retain={retain}
+        onQosChange={setQos}
+        onRetainChange={setRetain}
+      />
+    </PanelModalFrame>
+  );
+}
+
+interface TogglePanelProps {
+  panelId: string;
+  brokerId: string;
+  config: ToggleConfig;
+}
+
+interface PendingFlip {
+  desired: boolean;
+}
+
+/** Same HH:MM:SS footer format the gauge panel uses. */
+function formatTime(ms: number): string {
+  try {
+    const d = new Date(ms);
+    const pad2 = (n: number) => String(n).padStart(2, "0");
+    return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Remounts the runtime whenever the panel is pointed at a different broker,
+ * topic or payload mapping, so stale state is dropped without a reset effect.
+ */
+export default function TogglePanel(props: TogglePanelProps) {
+  const { brokerId, config } = props;
+  const identity = [
+    brokerId,
+    config.topic ?? "",
+    config.stateTopic ?? "",
+    config.onPayload ?? DEFAULT_ON_PAYLOAD,
+    config.offPayload ?? DEFAULT_OFF_PAYLOAD,
+    config.valueKey ?? "",
+  ].join("\u0000");
+
+  return <ToggleRuntime key={identity} {...props} />;
+}
+
+function ToggleRuntime({ panelId, brokerId, config }: TogglePanelProps) {
+  const [state, setState] = useState<boolean | null>(null);
+  const [updatedAt, setUpdatedAt] = useState<number | null>(null);
+  const [pending, setPending] = useState<PendingFlip | null>(null);
+  const [unconfirmed, setUnconfirmed] = useState(false);
+  const [error, setError] = useState(false);
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+  const [resizing, setResizing] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const pendingRef = useRef<PendingFlip | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resizeIdleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const commandTopic = (config.topic ?? "").split(",")[0]?.trim() ?? "";
+  const stateTopic = config.stateTopic?.trim() || commandTopic;
+  const onPayload = config.onPayload ?? DEFAULT_ON_PAYLOAD;
+  const offPayload = config.offPayload ?? DEFAULT_OFF_PAYLOAD;
+  const valueKey = config.valueKey;
+  const qos = config.qos ?? 0;
+  const retain = config.retain ?? false;
+  const hasWildcard = commandTopic.includes("+") || commandTopic.includes("#");
+
+  const clearPendingTimer = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  };
+
+  // A message from the state topic is the source of truth: it resolves any
+  // pending flip and replaces the optimistic position.
+  const applyIncomingState = (payload: string, receivedAt: number) => {
+    const next = parseToggleState(payload, { onPayload, offPayload, valueKey });
+    setState(next);
+    setUpdatedAt(receivedAt);
+
+    const inFlight = pendingRef.current;
+    if (inFlight) {
+      clearPendingTimer();
+      pendingRef.current = null;
+      setPending(null);
+      setUnconfirmed(next !== inFlight.desired);
+    }
+  };
+
+  useEffect(() => clearPendingTimer, []);
+
+  // Seed the last known state from history so a reload isn't blank
+  useEffect(() => {
+    if (!brokerId || !stateTopic) return;
+
+    let cancelled = false;
+    api
+      .getExplorerHistory(brokerId, stateTopic)
+      .then((records) => {
+        if (cancelled || !records || records.length === 0) return;
+        const sorted = [...records].sort(
+          (a, b) =>
+            new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+        );
+        const last = sorted[0];
+        const parsed = new Date(last.timestamp).getTime();
+        applyIncomingState(
+          last.payload,
+          Number.isNaN(parsed) ? Date.now() : parsed,
+        );
+      })
+      .catch(() => { });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [brokerId, stateTopic, onPayload, offPayload, valueKey]);
+
+  // Live updates
+  const { subscribe } = useWebSocket({
+    onMessage: (msgStr) => {
+      try {
+        const msg = JSON.parse(msgStr) as {
+          topic: string;
+          payload: string;
+          timestamp?: string;
+        };
+        const parsed = msg.timestamp
+          ? new Date(msg.timestamp).getTime()
+          : Date.now();
+        applyIncomingState(
+          msg.payload,
+          Number.isNaN(parsed) ? Date.now() : parsed,
+        );
+      } catch {
+        // Ignore invalid message JSON frame
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (!stateTopic) return;
+    subscribe({ panel_id: panelId, broker_id: brokerId, topics: [stateTopic] });
+  }, [panelId, brokerId, stateTopic, subscribe]);
+
+  // Scale the switch with the panel. Every animated property is derived from
+  // these dimensions, so transitions are suppressed until resizing settles —
+  // otherwise the knob chases each intermediate size and visibly jitters.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const apply = (w: number, h: number) => {
+      setDimensions({ width: w, height: h });
+      setResizing(true);
+      if (resizeIdleRef.current) clearTimeout(resizeIdleRef.current);
+      resizeIdleRef.current = setTimeout(() => setResizing(false), 150);
+    };
+
+    const measure = () => {
+      const w = el.offsetWidth;
+      const h = el.offsetHeight;
+      if (w > 0 && h > 0) apply(w, h);
+    };
+
+    measure();
+    const timer = setTimeout(measure, 100);
+
+    const cleanupTimers = () => {
+      clearTimeout(timer);
+      if (resizeIdleRef.current) clearTimeout(resizeIdleRef.current);
+    };
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", measure);
+      return () => {
+        cleanupTimers();
+        window.removeEventListener("resize", measure);
+      };
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        const w = entry.contentRect.width || el.offsetWidth;
+        const h = entry.contentRect.height || el.offsetHeight;
+        if (w > 0 && h > 0) apply(w, h);
+      }
+    });
+
+    observer.observe(el);
+    window.addEventListener("resize", measure);
+
+    return () => {
+      cleanupTimers();
+      observer.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, []);
+
+  const handleFlip = async (desired: boolean) => {
+    if (!commandTopic || hasWildcard || pendingRef.current) return;
+
+    setUnconfirmed(false);
+    setError(false);
+    const flip: PendingFlip = { desired };
+    pendingRef.current = flip;
+    setPending(flip);
+
+    clearPendingTimer();
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null;
+      pendingRef.current = null;
+      setPending(null);
+      setUnconfirmed(true);
+    }, CONFIRM_TIMEOUT_MS);
+
+    try {
+      await api.post("/api/publish", {
+        broker_id: brokerId,
+        topic: commandTopic,
+        payload: desired ? onPayload : offPayload,
+        qos,
+        retain,
+      });
+    } catch {
+      clearPendingTimer();
+      pendingRef.current = null;
+      setPending(null);
+      setError(true);
+    }
+  };
+
+  // Optimistic position while a flip is in flight, real state otherwise
+  const displayed = pending?.desired ?? state;
+  const isOn = displayed === true;
+  const disabled = !commandTopic || hasWildcard || pending !== null;
+
+  // Dynamic sizing derived from container dimensions, like GaugePanel.
+  // Height drives the switch so it never outgrows a short panel; width only
+  // caps it further on narrow ones.
+  const availW = Math.max(40, (dimensions.width || 240) - 16);
+  const availH = Math.max(40, (dimensions.height || 200) - 34);
+  const trackH = Math.round(
+    Math.max(18, Math.min(availH * 0.72, availW * 0.3, 150)),
+  );
+  const trackW = Math.round(trackH / 0.46);
+  const knobPad = Math.max(2, Math.round(trackH * 0.09));
+  const knobSize = trackH - knobPad * 2;
+  const stateFontSize = Math.max(9, Math.round(trackH * 0.32));
+  // Width of the half of the track the knob is not covering
+  const freeW = trackW - knobSize - knobPad * 2;
+
+  // Only transform/color animate, and neither during a resize
+  const motion = resizing
+    ? "none"
+    : "transform 200ms ease, background-color 200ms ease";
+
+  const trackClass =
+    displayed === null
+      ? "bg-base-300"
+      : displayed
+        ? "bg-success"
+        : "bg-error";
+  const stateTextClass =
+    displayed === null
+      ? "text-base-content/50"
+      : displayed
+        ? "text-success-content"
+        : "text-error-content";
+
+  let status: React.ReactNode = null;
+  if (!commandTopic) {
+    status = <span className="text-base-content/50">No topic configured</span>;
+  } else if (hasWildcard) {
+    status = (
+      <span className="text-warning inline-flex items-center gap-1">
+        <RiErrorWarningLine className="shrink-0" />
+        Wildcard topic
+      </span>
+    );
+  } else if (pending) {
+    status = (
+      <span className="text-base-content/60 inline-flex items-center gap-1">
+        <RiLoader4Line className="animate-spin shrink-0" />
+        confirming…
+      </span>
+    );
+  } else if (error) {
+    status = (
+      <span className="text-error inline-flex items-center gap-1">
+        <RiErrorWarningLine className="shrink-0" />
+        publish failed
+      </span>
+    );
+  } else if (unconfirmed) {
+    status = (
+      <span className="text-warning inline-flex items-center gap-1">
+        <RiErrorWarningLine className="shrink-0" />
+        not confirmed
+      </span>
+    );
+  } else if (updatedAt === null) {
+    status = <span className="text-base-content/50">waiting for state…</span>;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex flex-col h-full justify-between p-2 overflow-hidden"
+    >
+      <div className="flex flex-1 items-center justify-center min-h-0">
+        <button
+          type="button"
+          role="switch"
+          aria-checked={isOn}
+          aria-label={commandTopic || "Toggle"}
+          disabled={disabled}
+          onClick={() => handleFlip(!isOn)}
+          title={
+            hasWildcard
+              ? "Cannot publish to wildcard topics (+ or #)"
+              : !commandTopic
+                ? "No topic configured"
+                : undefined
+          }
+          className={`relative rounded-full shrink-0 ${trackClass} ${
+            disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
+          } ${pending ? "animate-pulse" : ""}`}
+          style={{ width: trackW, height: trackH, transition: motion }}
+        >
+          {/* Sits in the half the knob is not covering; slides with it */}
+          <span
+            className={`absolute flex items-center justify-center font-bold tracking-wide select-none ${stateTextClass}`}
+            style={{
+              top: knobPad,
+              height: knobSize,
+              left: knobPad + knobSize,
+              width: freeW,
+              transform: `translateX(${isOn ? -knobSize : 0}px)`,
+              transition: motion,
+              fontSize: stateFontSize,
+              lineHeight: 1,
+            }}
+          >
+            {displayed === null ? "—" : displayed ? "ON" : "OFF"}
+          </span>
+
+          <span
+            className="absolute rounded-full bg-base-100 shadow-md"
+            style={{
+              width: knobSize,
+              height: knobSize,
+              top: knobPad,
+              left: knobPad,
+              transform: `translateX(${isOn ? freeW : 0}px)`,
+              transition: motion,
+            }}
+          />
+        </button>
+      </div>
+
+      {/* Footer Meta */}
+      <div className="flex items-center justify-between gap-2 text-[10px] text-base-content/50 pt-1.5 border-t border-base-200 shrink-0">
+        <div className="flex items-center gap-1 min-w-0">
+          {updatedAt !== null && (
+            <>
+              <RiTimeLine className="text-xs shrink-0" />
+              <span className="truncate">{formatTime(updatedAt)}</span>
+            </>
+          )}
+        </div>
+        {status && <div className="truncate">{status}</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/panels/definitions.tsx
+++ b/frontend/src/components/panels/definitions.tsx
@@ -8,6 +8,7 @@ import {
   MdNotes,
   MdHorizontalRule,
   MdImage,
+  MdToggleOn,
 } from "react-icons/md";
 import { api } from "../../api/client";
 import type { PanelDefinition } from "./types";
@@ -29,6 +30,10 @@ import SeparatorPanel, {
   type SeparatorConfig,
 } from "./SeparatorPanel";
 import ImagePanel, { ImageConfigModal, type ImageConfig } from "./ImagePanel";
+import TogglePanel, {
+  ToggleConfigModal,
+  type ToggleConfig,
+} from "./TogglePanel";
 
 export const gaugePanelDefinition: PanelDefinition<GaugeConfig> = {
   type: "gauge",
@@ -247,6 +252,77 @@ export const cronPanelDefinition: PanelDefinition<CronConfig> = {
   Component: CronPanel,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConfigModal: CronConfigModal as any,
+};
+
+export const togglePanelDefinition: PanelDefinition<ToggleConfig> = {
+  type: "toggle",
+  label: "Toggle",
+  category: "control",
+  icon: MdToggleOn,
+  description: "Switch a device on or off and reflect its state",
+  resolvePickedTopic: (_existing, picked) => picked,
+  isEmpty: (config) =>
+    !config?.topic?.trim()
+      ? {
+          message: "No topic configured — open settings to add topic",
+          actionLabel: "Configure Topic",
+        }
+      : null,
+  // The generic validator only inspects `topic`. Wildcards are illegal on the
+  // command topic (it is published to) but fine on the state topic (read-only).
+  validateConfig: (config) => {
+    const topic = (config?.topic ?? "").trim();
+    if (!topic) {
+      return {
+        isValid: false,
+        warning: "No topic configured",
+        errors: { topic: "Topic is required" },
+      };
+    }
+    if (topic.includes("+") || topic.includes("#")) {
+      return {
+        isValid: false,
+        warning: "Cannot publish to wildcard topics (+ or #)",
+        errors: { topic: "Cannot publish to wildcard topics (+ or #)" },
+      };
+    }
+    if (!(config?.onPayload ?? "ON").trim() || !(config?.offPayload ?? "OFF").trim()) {
+      return {
+        isValid: false,
+        warning: "On and Off payloads are required",
+        errors: { payload: "On and Off payloads are required" },
+      };
+    }
+    return { isValid: true };
+  },
+  getHeaderMeta: (config) => {
+    const topic = (config?.topic ?? "").trim();
+    const stateTopic = config?.stateTopic?.trim();
+    if (!topic) return { topicSummary: "not configured" };
+    return {
+      topicSummary: stateTopic ? `${topic} ⇄ ${stateTopic}` : topic,
+      topicDetail: stateTopic
+        ? `command → ${topic} · state ← ${stateTopic}`
+        : `command and state → ${topic}`,
+      payloadPreview: `${(config?.onPayload ?? "ON").trim()} / ${(config?.offPayload ?? "OFF").trim()}`,
+    };
+  },
+  preview: (
+    <div className="flex flex-col items-center justify-center h-full gap-2 p-2">
+      <div className="relative rounded-full bg-success w-16 h-7">
+        <span className="absolute inset-y-1 left-1 right-8 flex items-center justify-center text-[10px] font-bold tracking-wide text-success-content">
+          ON
+        </span>
+        <span className="absolute top-1 right-1 w-5 h-5 rounded-full bg-base-100 shadow-md" />
+      </div>
+      <span className="text-[10px] text-base-content/50 font-mono">
+        home/lamp/set
+      </span>
+    </div>
+  ),
+  Component: TogglePanel,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ConfigModal: ToggleConfigModal as any,
 };
 
 export const textPanelDefinition: PanelDefinition<TextConfig> = {

--- a/frontend/src/components/panels/definitions.tsx
+++ b/frontend/src/components/panels/definitions.tsx
@@ -11,7 +11,7 @@ import {
   MdToggleOn,
 } from "react-icons/md";
 import { api } from "../../api/client";
-import type { PanelDefinition } from "./types";
+import type { PanelDefinition, ValidationResult } from "./types";
 import GaugePanel, { GaugeConfigModal, type GaugeConfig } from "./GaugePanel";
 import LogPanel, { LogConfigModal, type LogConfig } from "./LogPanel";
 import BrokerStatsPanel, {
@@ -270,7 +270,7 @@ export const togglePanelDefinition: PanelDefinition<ToggleConfig> = {
       : null,
   // The generic validator only inspects `topic`. Wildcards are illegal on the
   // command topic (it is published to) but fine on the state topic (read-only).
-  validateConfig: (config) => {
+  validateConfig: (config): ValidationResult => {
     const topic = (config?.topic ?? "").trim();
     if (!topic) {
       return {
@@ -286,7 +286,10 @@ export const togglePanelDefinition: PanelDefinition<ToggleConfig> = {
         errors: { topic: "Cannot publish to wildcard topics (+ or #)" },
       };
     }
-    if (!(config?.onPayload ?? "ON").trim() || !(config?.offPayload ?? "OFF").trim()) {
+    if (
+      !(config?.onPayload ?? "ON").trim() ||
+      !(config?.offPayload ?? "OFF").trim()
+    ) {
       return {
         isValid: false,
         warning: "On and Off payloads are required",

--- a/frontend/src/components/panels/index.ts
+++ b/frontend/src/components/panels/index.ts
@@ -6,6 +6,7 @@ import {
   buttonPanelDefinition,
   inputPanelDefinition,
   cronPanelDefinition,
+  togglePanelDefinition,
   textPanelDefinition,
   separatorPanelDefinition,
   imagePanelDefinition,
@@ -18,6 +19,7 @@ registerPanel(brokerStatsPanelDefinition);
 registerPanel(buttonPanelDefinition);
 registerPanel(inputPanelDefinition);
 registerPanel(cronPanelDefinition);
+registerPanel(togglePanelDefinition);
 registerPanel(textPanelDefinition);
 registerPanel(separatorPanelDefinition);
 registerPanel(imagePanelDefinition);

--- a/frontend/src/components/panels/registry.test.tsx
+++ b/frontend/src/components/panels/registry.test.tsx
@@ -22,9 +22,9 @@ afterEach(() => {
 });
 
 describe("Panel Registry", () => {
-  it("registers all 9 built-in panels by default", () => {
+  it("registers all 10 built-in panels by default", () => {
     const panels = getAllPanels();
-    expect(panels.length).toBeGreaterThanOrEqual(9);
+    expect(panels.length).toBeGreaterThanOrEqual(10);
 
     const types = panels.map((p) => p.type);
     expect(types).toContain("gauge");
@@ -33,6 +33,7 @@ describe("Panel Registry", () => {
     expect(types).toContain("button");
     expect(types).toContain("input");
     expect(types).toContain("cron");
+    expect(types).toContain("toggle");
     expect(types).toContain("text");
     expect(types).toContain("separator");
     expect(types).toContain("image");
@@ -46,7 +47,7 @@ describe("Panel Registry", () => {
 
     const controls = getPanelsByCategory("control").map((p) => p.type);
     expect(controls).toEqual(
-      expect.arrayContaining(["button", "input", "cron"]),
+      expect.arrayContaining(["button", "input", "cron", "toggle"]),
     );
     expect(controls).not.toContain("gauge");
     expect(controls).not.toContain("image");

--- a/frontend/src/components/panels/toggleUtils.test.ts
+++ b/frontend/src/components/panels/toggleUtils.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { extractPayloadValue, parseToggleState } from "./toggleUtils";
+
+describe("extractPayloadValue", () => {
+  it("returns the trimmed payload when no valueKey is set", () => {
+    expect(extractPayloadValue("  ON  ")).toBe("ON");
+  });
+
+  it("unwraps the configured key from a JSON object", () => {
+    expect(extractPayloadValue('{"state":"ON","rssi":-40}', "state")).toBe("ON");
+  });
+
+  it("stringifies non-string JSON values", () => {
+    expect(extractPayloadValue('{"state":true}', "state")).toBe("true");
+    expect(extractPayloadValue('{"state":1}', "state")).toBe("1");
+  });
+
+  it("falls back to the raw payload when the key is missing", () => {
+    expect(extractPayloadValue('{"other":"ON"}', "state")).toBe(
+      '{"other":"ON"}',
+    );
+  });
+
+  it("falls back to the raw payload when the payload is not JSON", () => {
+    expect(extractPayloadValue("ON", "state")).toBe("ON");
+  });
+
+  it("returns an empty string for null values", () => {
+    expect(extractPayloadValue('{"state":null}', "state")).toBe("");
+  });
+});
+
+describe("parseToggleState", () => {
+  it("matches the configured payloads", () => {
+    const opts = { onPayload: "1", offPayload: "0" };
+    expect(parseToggleState("1", opts)).toBe(true);
+    expect(parseToggleState("0", opts)).toBe(false);
+  });
+
+  it("matches configured payloads case-insensitively and ignores surrounding space", () => {
+    const opts = { onPayload: "On", offPayload: "Off" };
+    expect(parseToggleState(" on ", opts)).toBe(true);
+    expect(parseToggleState("OFF", opts)).toBe(false);
+  });
+
+  it("defaults to ON/OFF when no payloads are configured", () => {
+    expect(parseToggleState("ON")).toBe(true);
+    expect(parseToggleState("OFF")).toBe(false);
+  });
+
+  it("falls back to the shared truthiness table", () => {
+    expect(parseToggleState("true")).toBe(true);
+    expect(parseToggleState("online")).toBe(true);
+    expect(parseToggleState("no")).toBe(false);
+    expect(parseToggleState("offline")).toBe(false);
+  });
+
+  it("treats non-zero numbers as on", () => {
+    expect(parseToggleState("1")).toBe(true);
+    expect(parseToggleState("255")).toBe(true);
+    expect(parseToggleState("0")).toBe(false);
+  });
+
+  it("reads through a JSON valueKey", () => {
+    const opts = { valueKey: "state", onPayload: "ON", offPayload: "OFF" };
+    expect(parseToggleState('{"state":"ON"}', opts)).toBe(true);
+    expect(parseToggleState('{"state":"OFF"}', opts)).toBe(false);
+    expect(parseToggleState('{"state":true}', opts)).toBe(true);
+  });
+
+  it("prefers the configured payloads over the truthiness table", () => {
+    // "off" would normally be falsy, but it is configured as the ON payload here
+    expect(parseToggleState("off", { onPayload: "off", offPayload: "on" })).toBe(
+      true,
+    );
+  });
+
+  it("returns null for payloads it cannot map", () => {
+    expect(parseToggleState("something else")).toBeNull();
+    expect(parseToggleState("")).toBeNull();
+    expect(parseToggleState("   ")).toBeNull();
+  });
+
+  it("ignores blank configured payloads instead of matching everything", () => {
+    expect(parseToggleState("ON", { onPayload: "", offPayload: "" })).toBe(true);
+    expect(parseToggleState("whatever", { onPayload: "", offPayload: "" })).toBeNull();
+  });
+});

--- a/frontend/src/components/panels/toggleUtils.test.ts
+++ b/frontend/src/components/panels/toggleUtils.test.ts
@@ -7,7 +7,9 @@ describe("extractPayloadValue", () => {
   });
 
   it("unwraps the configured key from a JSON object", () => {
-    expect(extractPayloadValue('{"state":"ON","rssi":-40}', "state")).toBe("ON");
+    expect(extractPayloadValue('{"state":"ON","rssi":-40}', "state")).toBe(
+      "ON",
+    );
   });
 
   it("stringifies non-string JSON values", () => {
@@ -70,9 +72,9 @@ describe("parseToggleState", () => {
 
   it("prefers the configured payloads over the truthiness table", () => {
     // "off" would normally be falsy, but it is configured as the ON payload here
-    expect(parseToggleState("off", { onPayload: "off", offPayload: "on" })).toBe(
-      true,
-    );
+    expect(
+      parseToggleState("off", { onPayload: "off", offPayload: "on" }),
+    ).toBe(true);
   });
 
   it("returns null for payloads it cannot map", () => {
@@ -82,7 +84,11 @@ describe("parseToggleState", () => {
   });
 
   it("ignores blank configured payloads instead of matching everything", () => {
-    expect(parseToggleState("ON", { onPayload: "", offPayload: "" })).toBe(true);
-    expect(parseToggleState("whatever", { onPayload: "", offPayload: "" })).toBeNull();
+    expect(parseToggleState("ON", { onPayload: "", offPayload: "" })).toBe(
+      true,
+    );
+    expect(
+      parseToggleState("whatever", { onPayload: "", offPayload: "" }),
+    ).toBeNull();
   });
 });

--- a/frontend/src/components/panels/toggleUtils.ts
+++ b/frontend/src/components/panels/toggleUtils.ts
@@ -1,0 +1,62 @@
+import { parseGaugePayload } from "./gaugeUtils";
+
+export interface ToggleParseOptions {
+  onPayload?: string;
+  offPayload?: string;
+  valueKey?: string;
+}
+
+export const DEFAULT_ON_PAYLOAD = "ON";
+export const DEFAULT_OFF_PAYLOAD = "OFF";
+
+/**
+ * Pull the meaningful part out of a payload. With a valueKey set, a JSON object
+ * payload is unwrapped to that key; everything else is returned trimmed as-is.
+ */
+export function extractPayloadValue(payload: string, valueKey?: string): string {
+  if (!valueKey?.trim()) return payload.trim();
+
+  try {
+    const json = JSON.parse(payload);
+    if (typeof json === "object" && json !== null && !Array.isArray(json)) {
+      const key = valueKey.trim();
+      if (key in json) {
+        const target = (json as Record<string, unknown>)[key];
+        return target === null || target === undefined
+          ? ""
+          : String(target).trim();
+      }
+    }
+  } catch {
+    // Not JSON — fall through to the raw payload
+  }
+
+  return payload.trim();
+}
+
+/**
+ * Resolve an MQTT payload into a toggle position.
+ * Returns null when the payload cannot be mapped to on/off, so the panel can
+ * show "unknown" rather than guessing.
+ */
+export function parseToggleState(
+  payload: string,
+  options: ToggleParseOptions = {},
+): boolean | null {
+  const value = extractPayloadValue(payload, options.valueKey);
+  if (value === "") return null;
+
+  const onPayload = (options.onPayload ?? DEFAULT_ON_PAYLOAD).trim();
+  const offPayload = (options.offPayload ?? DEFAULT_OFF_PAYLOAD).trim();
+  const lower = value.toLowerCase();
+
+  if (onPayload && lower === onPayload.toLowerCase()) return true;
+  if (offPayload && lower === offPayload.toLowerCase()) return false;
+
+  // Fall back to the shared truthiness table (true/on/yes/online, numbers, ...)
+  const parsed = parseGaugePayload(value);
+  if (parsed.dataType === "boolean") return Boolean(parsed.parsedValue);
+  if (parsed.dataType === "number") return Number(parsed.parsedValue) !== 0;
+
+  return null;
+}

--- a/frontend/src/components/panels/toggleUtils.ts
+++ b/frontend/src/components/panels/toggleUtils.ts
@@ -13,7 +13,10 @@ export const DEFAULT_OFF_PAYLOAD = "OFF";
  * Pull the meaningful part out of a payload. With a valueKey set, a JSON object
  * payload is unwrapped to that key; everything else is returned trimmed as-is.
  */
-export function extractPayloadValue(payload: string, valueKey?: string): string {
+export function extractPayloadValue(
+  payload: string,
+  valueKey?: string,
+): string {
   if (!valueKey?.trim()) return payload.trim();
 
   try {

--- a/frontend/src/data/dashboardTemplates.test.ts
+++ b/frontend/src/data/dashboardTemplates.test.ts
@@ -14,6 +14,7 @@ const VALID_PANEL_TYPES = new Set([
   "separator",
   "image",
   "gauge",
+  "toggle",
 ]);
 
 describe("dashboardTemplates", () => {


### PR DESCRIPTION
Closes #132

Adds a **Toggle** panel — a stateful on/off control that publishes to a command topic and reflects the device's real state read back from MQTT. It fills the gap between the fire-and-forget `button` panel and the read-only `gauge`.

## What it does

- **Configurable topics.** One topic field by default (used to both publish and read state); a *"State topic is different"* checkbox reveals a second field for devices that report on a separate telemetry topic. Wildcards are rejected on the command topic and allowed on the state topic, since that one is read-only.
- **Configurable payloads.** On/Off payload strings (default `ON`/`OFF`) plus an optional JSON key, so `{"state":"ON"}`-style topics parse without extra work. Falls back to the shared truthiness table from `gaugeUtils` (`true/on/yes/online`, non-zero numbers), and shows `—` rather than guessing when a payload can't be mapped.
- **Optimistic with confirmation.** The switch moves immediately and pulses while awaiting the echo from the state topic. On confirmation it settles; on a disagreeing echo or 5s of silence it shows the real state and flags *not confirmed*. State always comes from MQTT, never from `config_json`.
- **History bootstrap.** Seeds the last known value via `getExplorerHistory`, so a page reload isn't blank.
- **Sizes like the gauge.** Measures its container with a `ResizeObserver` and derives real pixel dimensions, with the last-update time in a footer matching `GaugePanel`'s.

## Notes

- **No backend changes.** `panel_type` is an opaque `TEXT` column and only `separator`/`cron` are special-cased, so registering the panel in `index.ts` is the whole wiring.
- The switch is hand-drawn rather than a daisyUI `.toggle` for two reasons: the ON/OFF label sits *inside* the track, and daisyUI sizes toggles by class, which can't follow a resizable grid cell. Colors remain semantic (`bg-success`/`bg-error`/`bg-base-300` with matching `*-content` text).
- Motion is `transform`-only and suppressed while resizing — animating size-derived properties made the knob chase intermediate resize frames and visibly jitter.
- `registry.test.tsx` and `dashboardTemplates.test.ts` hardcode the panel-type list and are updated accordingly.

## Testing

- `toggleUtils.test.ts` — 15 unit tests covering payload extraction and state resolution.
- Full suite: 83 passing. `tsc --noEmit` and ESLint clean.
- Verified end-to-end against the dev stack: publish → broker → history round-trip on a real Mosquitto broker.
- Behaviour verified headlessly (history seeding, pending → confirmed, the 5s revert, wildcard lockout, unknown-payload state). Per `AGENTS.md` the frontend component test was throwaway and is not committed.

⚠️ **Not verified in a browser** — no browser tooling was available in the session, so the visual result and the resize behaviour are reasoned from the CSS rather than observed. Worth a drag-resize before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E12AVJgMLjg8tUa4XEEiwN