### PR TITLE
chore(ci): make the Prettier check fail on formatting drift

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -27,7 +27,7 @@ jobs:
 
             - name: Check for Prettier issues
               working-directory: frontend
-              run: npm run prettier -- --check .
+              run: npm run prettier:check
 
             - name: Lint
               working-directory: frontend

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -66,15 +66,15 @@ frontend/
 
 ## 🛠️ Available Scripts
 
-| Command | Description |
-| ------- | ----------- |
-| `npm run dev` | Start local Vite development server with proxying to `:8080` |
-| `npm run build` | Run TypeScript type checks (`tsc -b`) and bundle for production (`dist/`) |
-| `npm run test` | Run unit tests using Vitest in single-run mode |
-| `npm run test:watch` | Run Vitest in interactive watch mode |
-| `npm run lint` | Check code with ESLint |
-| `npm run prettier` | Format codebase using Prettier |
-| `npm run preview` | Locally preview the production build in `dist/` |
+| Command              | Description                                                               |
+| -------------------- | ------------------------------------------------------------------------- |
+| `npm run dev`        | Start local Vite development server with proxying to `:8080`              |
+| `npm run build`      | Run TypeScript type checks (`tsc -b`) and bundle for production (`dist/`) |
+| `npm run test`       | Run unit tests using Vitest in single-run mode                            |
+| `npm run test:watch` | Run Vitest in interactive watch mode                                      |
+| `npm run lint`       | Check code with ESLint                                                    |
+| `npm run prettier`   | Format codebase using Prettier                                            |
+| `npm run preview`    | Locally preview the production build in `dist/`                           |
 
 ---
 
@@ -88,4 +88,3 @@ frontend/
 - **Routing:** [React Router 7](https://reactrouter.com/)
 - **Cron Formatter:** [cronstrue](https://github.com/bradymholt/cronstrue)
 - **Testing:** [Vitest](https://vitest.dev/) + [React Testing Library](https://testing-library.com/)
-

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "preview": "vite preview",
-    "prettier": "prettier --write ."
+    "prettier": "prettier --write .",
+    "prettier:check": "prettier --check ."
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/frontend/src/components/PanelLibraryModal.tsx
+++ b/frontend/src/components/PanelLibraryModal.tsx
@@ -125,10 +125,7 @@ function PanelLibraryModalInner({ onClose, onPick }: Omit<Props, "open">) {
                       >
                         <div className="flex items-center justify-between w-full">
                           <span className="w-8 h-8 rounded-md bg-base-100 border border-base-300 flex items-center justify-center shrink-0">
-                            <Icon
-                              size={16}
-                              className="text-base-content/70"
-                            />
+                            <Icon size={16} className="text-base-content/70" />
                           </span>
                           <span className="text-[9.5px] uppercase tracking-widest text-base-content/40">
                             {p.category}

--- a/frontend/src/components/PanelWrapper.tsx
+++ b/frontend/src/components/PanelWrapper.tsx
@@ -359,8 +359,7 @@ export default function PanelWrapper({
     const brokerId = panel.broker_id ?? "";
     const ConfigModal = def.ConfigModal;
 
-    const resolveTopicFn =
-      def.resolvePickedTopic ?? defaultResolvePickedTopic;
+    const resolveTopicFn = def.resolvePickedTopic ?? defaultResolvePickedTopic;
     const initialTopic = resolveTopicFn(
       (cfg.topic ?? cfg.topics) as string | undefined,
       capturedPicker.topic,

--- a/frontend/src/components/explorer/ExplorerPublishPanel.tsx
+++ b/frontend/src/components/explorer/ExplorerPublishPanel.tsx
@@ -41,7 +41,10 @@ export default function ExplorerPublishPanel({
           </button>
         </div>
         <p className="text-[11px] text-base-content/60 leading-normal pr-4">
-          Topics with wildcards (<code className="font-mono text-warning">+</code> or <code className="font-mono text-warning">#</code>) cannot receive published messages. Select a specific sub-topic to publish.
+          Topics with wildcards (
+          <code className="font-mono text-warning">+</code> or{" "}
+          <code className="font-mono text-warning">#</code>) cannot receive
+          published messages. Select a specific sub-topic to publish.
         </p>
       </div>
     );

--- a/frontend/src/components/panels/BrokerStatsPanel.tsx
+++ b/frontend/src/components/panels/BrokerStatsPanel.tsx
@@ -129,9 +129,7 @@ export function BrokerStatsConfigModal({
         <select
           className="select select-bordered select-sm w-full font-medium"
           value={defaultRange}
-          onChange={(e) =>
-            setDefaultRange(Number(e.target.value) as TimeRange)
-          }
+          onChange={(e) => setDefaultRange(Number(e.target.value) as TimeRange)}
         >
           <option value={60}>1 minute</option>
           <option value={300}>5 minutes</option>
@@ -149,18 +147,16 @@ export function BrokerStatsConfigModal({
             [
               [showStatTiles, setShowStatTiles, "Stat tiles"],
               [showChart, setShowChart, "Chart"],
-              [
-                showTopicBreakdown,
-                setShowTopicBreakdown,
-                "Topic breakdown",
-              ],
+              [showTopicBreakdown, setShowTopicBreakdown, "Topic breakdown"],
             ] as [boolean, (v: boolean) => void, string][]
           ).map(([value, setter, label]) => (
             <label
               key={label}
               className="flex items-center justify-between cursor-pointer p-2.5 rounded-lg border border-base-300 bg-base-200/40"
             >
-              <span className="text-xs font-medium text-base-content/80">{label}</span>
+              <span className="text-xs font-medium text-base-content/80">
+                {label}
+              </span>
               <input
                 type="checkbox"
                 className="toggle toggle-xs toggle-primary"

--- a/frontend/src/components/panels/BrokerTopicSection.tsx
+++ b/frontend/src/components/panels/BrokerTopicSection.tsx
@@ -44,8 +44,8 @@ export default function BrokerTopicSection({
         ? "e.g. sensors/+, home/#"
         : "e.g. home/living/light, home/kitchen/light"
       : allowWildcards
-      ? "e.g. sensor/temperature, sensor/+"
-      : "e.g. sensor/temperature");
+        ? "e.g. sensor/temperature, sensor/+"
+        : "e.g. sensor/temperature");
 
   const effectiveHelpText =
     helpText ??
@@ -54,8 +54,8 @@ export default function BrokerTopicSection({
         ? "Separate multiple topics with commas. Supports wildcards: + (single level) and # (multi-level), e.g. sensors/+/temp, home/#."
         : "Separate multiple topics with commas."
       : allowWildcards
-      ? "Supports wildcards: + (single level) and # (multi-level), e.g. sensors/+/temp."
-      : "Specify a single topic.");
+        ? "Supports wildcards: + (single level) and # (multi-level), e.g. sensors/+/temp."
+        : "Specify a single topic.");
 
   // Parse comma-separated topics for visual badge preview
   const parsedTopics = useMemo(() => {
@@ -154,7 +154,11 @@ export default function BrokerTopicSection({
             <div className="flex-1 min-w-0">
               <input
                 className={`input input-bordered input-sm w-full font-mono text-xs ${
-                  hasWildcardWarning || hasMultipleTopicsWarning || !topic?.trim() ? "input-warning" : ""
+                  hasWildcardWarning ||
+                  hasMultipleTopicsWarning ||
+                  !topic?.trim()
+                    ? "input-warning"
+                    : ""
                 }`}
                 placeholder={effectivePlaceholder}
                 value={topic}
@@ -181,7 +185,8 @@ export default function BrokerTopicSection({
             >
               <WarningIcon className="text-sm shrink-0" />
               <span>
-                No topic configured. Panel will not receive or publish messages until a topic is set.
+                No topic configured. Panel will not receive or publish messages
+                until a topic is set.
               </span>
             </div>
           )}
@@ -202,7 +207,8 @@ export default function BrokerTopicSection({
                         : "bg-base-100 border border-base-300 text-base-content"
                     }`}
                   >
-                    {isInvalidWildcard || (hasMultipleTopicsWarning && idx > 0) ? (
+                    {isInvalidWildcard ||
+                    (hasMultipleTopicsWarning && idx > 0) ? (
                       <WarningIcon className="text-warning text-xs shrink-0" />
                     ) : (
                       <span className="text-secondary opacity-70">#</span>
@@ -230,7 +236,8 @@ export default function BrokerTopicSection({
             >
               <WarningIcon className="text-sm shrink-0" />
               <span>
-                Multiple topics (comma-separated) are not supported for this panel. Please specify a single topic.
+                Multiple topics (comma-separated) are not supported for this
+                panel. Please specify a single topic.
               </span>
             </div>
           )}
@@ -243,7 +250,8 @@ export default function BrokerTopicSection({
             >
               <WarningIcon className="text-sm shrink-0" />
               <span>
-                Wildcards (<strong>+</strong> or <strong>#</strong>) are not supported when publishing. Please use exact topic names.
+                Wildcards (<strong>+</strong> or <strong>#</strong>) are not
+                supported when publishing. Please use exact topic names.
               </span>
             </div>
           )}

--- a/frontend/src/components/panels/ButtonPanel.tsx
+++ b/frontend/src/components/panels/ButtonPanel.tsx
@@ -52,8 +52,7 @@ export function ButtonConfigModal({
     initialBrokerId || brokerId || defaultBrokerId,
   );
 
-  const hasWildcardWarning =
-    topic.includes("+") || topic.includes("#");
+  const hasWildcardWarning = topic.includes("+") || topic.includes("#");
 
   return (
     <PanelModalFrame
@@ -149,12 +148,14 @@ export default function ButtonPanel({ brokerId, config }: ButtonPanelProps) {
   const rawTopic = config.topic ?? "";
   const parsedTopics = rawTopic
     ? rawTopic
-      .split(",")
-      .map((t) => t.trim())
-      .filter(Boolean)
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean)
     : [];
 
-  const hasWildcard = parsedTopics.some((t) => t.includes("+") || t.includes("#"));
+  const hasWildcard = parsedTopics.some(
+    (t) => t.includes("+") || t.includes("#"),
+  );
 
   const publishMessage = async () => {
     if (parsedTopics.length === 0 || hasWildcard) return;
@@ -212,7 +213,7 @@ export default function ButtonPanel({ brokerId, config }: ButtonPanelProps) {
         {loading ? (
           <span className="loading loading-spinner" />
         ) : (
-          config.label ?? "Click"
+          (config.label ?? "Click")
         )}
       </button>
 
@@ -221,7 +222,11 @@ export default function ButtonPanel({ brokerId, config }: ButtonPanelProps) {
           <div className="modal-box max-w-sm p-5">
             <h3 className="font-bold text-base mb-2">Confirm Action</h3>
             <p className="text-xs text-base-content/80 mb-3">
-              Are you sure you want to send this message to {parsedTopics.length === 1 ? "topic" : `${parsedTopics.length} topics`}?
+              Are you sure you want to send this message to{" "}
+              {parsedTopics.length === 1
+                ? "topic"
+                : `${parsedTopics.length} topics`}
+              ?
             </p>
             <div className="flex flex-wrap gap-1 mb-4 max-h-28 overflow-y-auto">
               {parsedTopics.map((t, idx) => (

--- a/frontend/src/components/panels/CronPanel.tsx
+++ b/frontend/src/components/panels/CronPanel.tsx
@@ -329,7 +329,11 @@ export default function CronPanel({
           className="toggle toggle-primary"
           checked={config.enabled ?? false}
           disabled={toggling || !config.cron_expr || hasWildcard}
-          title={hasWildcard ? "Cannot publish to wildcard topics (+ or #)" : undefined}
+          title={
+            hasWildcard
+              ? "Cannot publish to wildcard topics (+ or #)"
+              : undefined
+          }
           onChange={(e) => handleToggle(e.target.checked)}
         />
       </div>

--- a/frontend/src/components/panels/GaugePanel.tsx
+++ b/frontend/src/components/panels/GaugePanel.tsx
@@ -15,14 +15,14 @@ export interface GaugeConfig {
   min?: number;
   max?: number;
   colorScheme?:
-  | "auto"
-  | "primary"
-  | "secondary"
-  | "accent"
-  | "success"
-  | "warning"
-  | "error"
-  | "info";
+    | "auto"
+    | "primary"
+    | "secondary"
+    | "accent"
+    | "success"
+    | "warning"
+    | "error"
+    | "info";
   gaugeType?: "radial" | "bar" | "value";
 }
 
@@ -65,8 +65,12 @@ export function GaugeConfigModal({
     initialBrokerId || brokerId || defaultBrokerId,
   );
 
-  const [detectedType, setDetectedType] = useState<"number" | "boolean" | "string" | null>(null);
-  const [sampleValue, setSampleValue] = useState<string | number | boolean | null>(null);
+  const [detectedType, setDetectedType] = useState<
+    "number" | "boolean" | "string" | null
+  >(null);
+  const [sampleValue, setSampleValue] = useState<
+    string | number | boolean | null
+  >(null);
   const [detectedKey, setDetectedKey] = useState<string | null>(null);
   const [isLoadingSample, setIsLoadingSample] = useState(false);
 
@@ -93,14 +97,19 @@ export function GaugeConfigModal({
         if (cancelled) return;
         if (records && records.length > 0) {
           const sorted = [...records].sort(
-            (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+            (a, b) =>
+              new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
           );
           const latest = sorted[0];
           if (latest?.payload) {
             let keyCandidate: string | null = null;
             try {
               const json = JSON.parse(latest.payload);
-              if (typeof json === "object" && json !== null && !Array.isArray(json)) {
+              if (
+                typeof json === "object" &&
+                json !== null &&
+                !Array.isArray(json)
+              ) {
                 const commonKeys = [
                   "val",
                   "value",
@@ -129,7 +138,10 @@ export function GaugeConfigModal({
             setSampleValue(parsed.parsedValue);
             setIsLoadingSample(false);
 
-            if (parsed.dataType !== "number" && (gaugeType === "radial" || gaugeType === "bar")) {
+            if (
+              parsed.dataType !== "number" &&
+              (gaugeType === "radial" || gaugeType === "bar")
+            ) {
               setGaugeType("value");
             }
             return;
@@ -174,20 +186,20 @@ export function GaugeConfigModal({
       }
     >
       <div className="flex flex-col gap-4">
-          <BrokerTopicSection
-            selectedBrokerId={selectedBrokerId}
-            onBrokerChange={setSelectedBrokerId}
-            brokerStatuses={brokerStatuses}
-            topic={topic}
-            onTopicChange={setTopic}
-            allowWildcards={true}
-            allowMultiple={false}
-            topicLabel="Topic"
-            placeholder="e.g. sensor/temperature"
-            helpText="Single topic to monitor for live data values (wildcards supported)."
-            onPickTopic={
-              onPickTopic
-                ? () =>
+        <BrokerTopicSection
+          selectedBrokerId={selectedBrokerId}
+          onBrokerChange={setSelectedBrokerId}
+          brokerStatuses={brokerStatuses}
+          topic={topic}
+          onTopicChange={setTopic}
+          allowWildcards={true}
+          allowMultiple={false}
+          topicLabel="Topic"
+          placeholder="e.g. sensor/temperature"
+          helpText="Single topic to monitor for live data values (wildcards supported)."
+          onPickTopic={
+            onPickTopic
+              ? () =>
                   onPickTopic({
                     currentTopic: topic,
                     selectedBrokerId,
@@ -200,170 +212,181 @@ export function GaugeConfigModal({
                       gaugeType,
                     },
                   })
-                : undefined
-            }
-          />
+              : undefined
+          }
+        />
 
-          {/* Payload Detection Banner */}
-          <div className="flex items-center justify-between gap-2 px-3 py-2 bg-base-200/60 rounded-lg text-xs border border-base-300">
-            <span className="font-medium text-base-content/70 shrink-0">
-              Detected Payload Type:
-            </span>
+        {/* Payload Detection Banner */}
+        <div className="flex items-center justify-between gap-2 px-3 py-2 bg-base-200/60 rounded-lg text-xs border border-base-300">
+          <span className="font-medium text-base-content/70 shrink-0">
+            Detected Payload Type:
+          </span>
 
-            <div className="flex items-center gap-2 min-w-0">
-              {sampleValue !== null && (
-                <>
-                  <span
-                    className="font-mono text-[11px] text-base-content/80 truncate max-w-[180px] bg-base-100 px-2 py-0.5 rounded border border-base-300"
-                    title={String(sampleValue)}
-                  >
-                    {String(sampleValue)}
-                  </span>
-                  <span className="text-base-content/40 font-mono text-xs font-semibold shrink-0">
-                    →
-                  </span>
-                </>
-              )}
+          <div className="flex items-center gap-2 min-w-0">
+            {sampleValue !== null && (
+              <>
+                <span
+                  className="font-mono text-[11px] text-base-content/80 truncate max-w-[180px] bg-base-100 px-2 py-0.5 rounded border border-base-300"
+                  title={String(sampleValue)}
+                >
+                  {String(sampleValue)}
+                </span>
+                <span className="text-base-content/40 font-mono text-xs font-semibold shrink-0">
+                  →
+                </span>
+              </>
+            )}
 
-              {detectedType === "number" && (
-                <span className="badge badge-info badge-sm font-semibold shrink-0">
-                  Number
-                </span>
-              )}
-              {detectedType === "boolean" && (
-                <span className="badge badge-success badge-sm font-semibold shrink-0">
-                  Boolean
-                </span>
-              )}
-              {detectedType === "string" && (
-                <span className="badge badge-accent badge-sm font-semibold shrink-0">
-                  String
-                </span>
-              )}
-              {!detectedType && !isLoadingSample && (
-                <span className="badge badge-ghost badge-sm text-base-content/50 shrink-0">
-                  No sample data
-                </span>
-              )}
-            </div>
+            {detectedType === "number" && (
+              <span className="badge badge-info badge-sm font-semibold shrink-0">
+                Number
+              </span>
+            )}
+            {detectedType === "boolean" && (
+              <span className="badge badge-success badge-sm font-semibold shrink-0">
+                Boolean
+              </span>
+            )}
+            {detectedType === "string" && (
+              <span className="badge badge-accent badge-sm font-semibold shrink-0">
+                String
+              </span>
+            )}
+            {!detectedType && !isLoadingSample && (
+              <span className="badge badge-ghost badge-sm text-base-content/50 shrink-0">
+                No sample data
+              </span>
+            )}
           </div>
+        </div>
 
-          {/* JSON Key Section */}
-          <fieldset className="fieldset w-full">
-            <div className="flex items-center justify-between">
-              <legend className="fieldset-legend font-semibold">JSON Key (Optional)</legend>
-              {detectedKey && (
-                <div className="flex items-center gap-1.5">
-                  <span className="text-[11px] text-base-content/70">Detected:</span>
-                  <button
-                    type="button"
-                    className="font-mono text-[11px] text-primary hover:text-primary-focus bg-base-100 hover:bg-base-200/80 px-2 py-0.5 rounded border border-base-300 transition-colors gap-1 inline-flex items-center cursor-pointer"
-                    title={`Click to use detected key "${detectedKey}"`}
-                    onClick={() => setValueKey(detectedKey)}
-                  >
-                    <span>"{detectedKey}"</span>
-                    <span className="badge badge-primary badge-xs ml-0.5 font-sans font-normal text-[10px]">Use</span>
-                  </button>
-                </div>
-              )}
-            </div>
-            <div className="relative w-full">
-              <input
-                className="input input-bordered input-sm w-full font-mono text-xs pr-8"
-                placeholder="e.g. temp or data.value"
-                value={valueKey}
-                onChange={(e) => setValueKey(e.target.value)}
-              />
-              {valueKey && (
+        {/* JSON Key Section */}
+        <fieldset className="fieldset w-full">
+          <div className="flex items-center justify-between">
+            <legend className="fieldset-legend font-semibold">
+              JSON Key (Optional)
+            </legend>
+            {detectedKey && (
+              <div className="flex items-center gap-1.5">
+                <span className="text-[11px] text-base-content/70">
+                  Detected:
+                </span>
                 <button
                   type="button"
-                  className="absolute right-2 top-1/2 -translate-y-1/2 btn btn-xs btn-ghost btn-circle text-base-content/50 hover:text-base-content"
-                  title="Clear JSON Key"
-                  onClick={() => setValueKey("")}
+                  className="font-mono text-[11px] text-primary hover:text-primary-focus bg-base-100 hover:bg-base-200/80 px-2 py-0.5 rounded border border-base-300 transition-colors gap-1 inline-flex items-center cursor-pointer"
+                  title={`Click to use detected key "${detectedKey}"`}
+                  onClick={() => setValueKey(detectedKey)}
                 >
-                  ✕
+                  <span>"{detectedKey}"</span>
+                  <span className="badge badge-primary badge-xs ml-0.5 font-sans font-normal text-[10px]">
+                    Use
+                  </span>
                 </button>
-              )}
-            </div>
-            <p className="text-[11px] text-base-content/60 mt-1">
-              Field name to extract if payload is JSON. Leave blank to display the raw payload.
-            </p>
-          </fieldset>
-
-          {/* Full-width Gauge Style Selector */}
-          <fieldset className="fieldset w-full">
-            <legend className="fieldset-legend font-semibold">Gauge Style</legend>
-            <select
-              className="select select-bordered select-sm w-full font-medium"
-              value={gaugeType}
-              onChange={(e) =>
-                setGaugeType(e.target.value as GaugeConfig["gaugeType"])
-              }
-            >
-              <option
-                value="radial"
-                disabled={detectedType !== null && detectedType !== "number"}
-              >
-                Radial Ring Dial{" "}
-                {detectedType !== null && detectedType !== "number"
-                  ? "(Disabled: Requires numeric data)"
-                  : ""}
-              </option>
-              <option
-                value="bar"
-                disabled={detectedType !== null && detectedType !== "number"}
-              >
-                Progress Bar Meter{" "}
-                {detectedType !== null && detectedType !== "number"
-                  ? "(Disabled: Requires numeric data)"
-                  : ""}
-              </option>
-              <option value="value">
-                Big Value Card (Compatible with Numbers, Booleans & Strings)
-              </option>
-            </select>
-            {detectedType !== null && detectedType !== "number" && (
-              <p className="text-[11px] text-warning mt-1">
-                Radial and Progress Bar gauges require numeric payloads to calculate min/max percentages. "Big Value Card" has been auto-selected.
-              </p>
+              </div>
             )}
+          </div>
+          <div className="relative w-full">
+            <input
+              className="input input-bordered input-sm w-full font-mono text-xs pr-8"
+              placeholder="e.g. temp or data.value"
+              value={valueKey}
+              onChange={(e) => setValueKey(e.target.value)}
+            />
+            {valueKey && (
+              <button
+                type="button"
+                className="absolute right-2 top-1/2 -translate-y-1/2 btn btn-xs btn-ghost btn-circle text-base-content/50 hover:text-base-content"
+                title="Clear JSON Key"
+                onClick={() => setValueKey("")}
+              >
+                ✕
+              </button>
+            )}
+          </div>
+          <p className="text-[11px] text-base-content/60 mt-1">
+            Field name to extract if payload is JSON. Leave blank to display the
+            raw payload.
+          </p>
+        </fieldset>
+
+        {/* Full-width Gauge Style Selector */}
+        <fieldset className="fieldset w-full">
+          <legend className="fieldset-legend font-semibold">Gauge Style</legend>
+          <select
+            className="select select-bordered select-sm w-full font-medium"
+            value={gaugeType}
+            onChange={(e) =>
+              setGaugeType(e.target.value as GaugeConfig["gaugeType"])
+            }
+          >
+            <option
+              value="radial"
+              disabled={detectedType !== null && detectedType !== "number"}
+            >
+              Radial Ring Dial{" "}
+              {detectedType !== null && detectedType !== "number"
+                ? "(Disabled: Requires numeric data)"
+                : ""}
+            </option>
+            <option
+              value="bar"
+              disabled={detectedType !== null && detectedType !== "number"}
+            >
+              Progress Bar Meter{" "}
+              {detectedType !== null && detectedType !== "number"
+                ? "(Disabled: Requires numeric data)"
+                : ""}
+            </option>
+            <option value="value">
+              Big Value Card (Compatible with Numbers, Booleans & Strings)
+            </option>
+          </select>
+          {detectedType !== null && detectedType !== "number" && (
+            <p className="text-[11px] text-warning mt-1">
+              Radial and Progress Bar gauges require numeric payloads to
+              calculate min/max percentages. "Big Value Card" has been
+              auto-selected.
+            </p>
+          )}
+        </fieldset>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <fieldset className="fieldset">
+            <legend className="fieldset-legend">Min Value</legend>
+            <input
+              className="input input-bordered input-sm w-full"
+              type="number"
+              value={min}
+              onChange={(e) => setMin(Number(e.target.value))}
+            />
           </fieldset>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <fieldset className="fieldset">
-              <legend className="fieldset-legend">Min Value</legend>
-              <input
-                className="input input-bordered input-sm w-full"
-                type="number"
-                value={min}
-                onChange={(e) => setMin(Number(e.target.value))}
-              />
-            </fieldset>
-
-            <fieldset className="fieldset">
-              <legend className="fieldset-legend">Max Value</legend>
-              <input
-                className="input input-bordered input-sm w-full"
-                type="number"
-                value={max}
-                onChange={(e) => setMax(Number(e.target.value))}
-              />
-            </fieldset>
-          </div>
-
-          <fieldset className="fieldset w-full">
-            <legend className="fieldset-legend font-semibold">Unit / Suffix</legend>
+          <fieldset className="fieldset">
+            <legend className="fieldset-legend">Max Value</legend>
             <input
-              className="input input-bordered input-sm w-full text-xs"
-              placeholder="e.g. °C, %, V, kW"
-              value={unit}
-              onChange={(e) => setUnit(e.target.value)}
+              className="input input-bordered input-sm w-full"
+              type="number"
+              value={max}
+              onChange={(e) => setMax(Number(e.target.value))}
             />
-            <p className="text-[11px] text-base-content/60 mt-1">
-              Displayed next to the value.
-            </p>
           </fieldset>
         </div>
+
+        <fieldset className="fieldset w-full">
+          <legend className="fieldset-legend font-semibold">
+            Unit / Suffix
+          </legend>
+          <input
+            className="input input-bordered input-sm w-full text-xs"
+            placeholder="e.g. °C, %, V, kW"
+            value={unit}
+            onChange={(e) => setUnit(e.target.value)}
+          />
+          <p className="text-[11px] text-base-content/60 mt-1">
+            Displayed next to the value.
+          </p>
+        </fieldset>
+      </div>
     </PanelModalFrame>
   );
 }
@@ -385,15 +408,17 @@ function formatTime(isoStr: string): string {
   }
 }
 
-
-
 interface GaugePanelProps {
   panelId: string;
   brokerId: string;
   config: GaugeConfig;
 }
 
-export default function GaugePanel({ panelId, brokerId, config }: GaugePanelProps) {
+export default function GaugePanel({
+  panelId,
+  brokerId,
+  config,
+}: GaugePanelProps) {
   const [data, setData] = useState<{
     parsedValue: string | number | boolean;
     dataType: "number" | "boolean" | "string";
@@ -403,7 +428,10 @@ export default function GaugePanel({ panelId, brokerId, config }: GaugePanelProp
   } | null>(null);
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const [dimensions, setDimensions] = useState<{ width: number; height: number }>({
+  const [dimensions, setDimensions] = useState<{
+    width: number;
+    height: number;
+  }>({
     width: 0,
     height: 0,
   });
@@ -487,7 +515,7 @@ export default function GaugePanel({ panelId, brokerId, config }: GaugePanelProp
           isHistorical: true,
         });
       })
-      .catch(() => { });
+      .catch(() => {});
 
     return () => {
       cancelled = true;
@@ -596,7 +624,10 @@ export default function GaugePanel({ panelId, brokerId, config }: GaugePanelProp
   const barSubFontSize = Math.max(10, Math.round(barValFontSize * 0.45));
 
   // Value Card / String / Boolean Sizing: hero text/badge
-  const strLen = Math.max(1, formattedValue.length + (unit ? unit.length + 1 : 0));
+  const strLen = Math.max(
+    1,
+    formattedValue.length + (unit ? unit.length + 1 : 0),
+  );
   const maxFontFromHeight = availH * 0.42;
   const maxFontFromWidth = (availW * 0.95) / Math.max(1, strLen * 0.65);
   const cardValFontSize = Math.max(
@@ -609,7 +640,10 @@ export default function GaugePanel({ panelId, brokerId, config }: GaugePanelProp
   );
 
   return (
-    <div ref={containerRef} className="flex flex-col h-full justify-between p-2">
+    <div
+      ref={containerRef}
+      className="flex flex-col h-full justify-between p-2"
+    >
       {!topic ? (
         <div className="flex flex-col items-center justify-center flex-1 gap-2 text-base-content/40 p-4 text-center">
           <MdSpeed className="text-4xl opacity-50" />
@@ -622,167 +656,170 @@ export default function GaugePanel({ panelId, brokerId, config }: GaugePanelProp
         <div className="flex flex-col items-center justify-center flex-1 gap-2 p-4 text-center">
           <div className="loading loading-spinner loading-md text-primary" />
           <span className="text-xs text-base-content/60 font-mono animate-pulse">
-            Waiting for data on <span className="font-semibold text-accent">{topic}</span>…
+            Waiting for data on{" "}
+            <span className="font-semibold text-accent">{topic}</span>…
           </span>
         </div>
       ) : (
         <>
           {/* Visual Display Container */}
           <div className="flex-1 flex items-center justify-center min-h-0 w-full overflow-hidden p-1">
-        {data.dataType === "number" && gaugeType === "radial" && (
-          <div
-            className="relative flex items-center justify-center shrink-0"
-            style={{ width: `${dialSize}px`, height: `${dialSize}px` }}
-            role="progressbar"
-            aria-valuenow={Math.round(pct)}
-            aria-valuemin={min}
-            aria-valuemax={max}
-          >
-            <svg
-              viewBox="0 0 100 100"
-              className="w-full h-full transform -rotate-90 overflow-visible"
-            >
-              {/* Background Track Circle */}
-              <circle
-                cx="50"
-                cy="50"
-                r="40"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="8"
-                className="text-base-content/10"
-              />
-              {/* Animated Progress Fill Arc */}
-              <circle
-                cx="50"
-                cy="50"
-                r="40"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="8"
-                strokeLinecap="round"
-                strokeDasharray="251.327"
-                strokeDashoffset={251.327 - (pct / 100) * 251.327}
-                className={`${colorClass} transition-[stroke-dashoffset] duration-500 ease-out`}
-              />
-            </svg>
-            {/* Center Value Text */}
-            <div className="absolute inset-0 flex flex-col items-center justify-center p-1 text-center leading-none pointer-events-none">
-              <span
-                className="font-bold font-mono tracking-tight text-base-content"
-                style={{ fontSize: `${radialValFontSize}px` }}
+            {data.dataType === "number" && gaugeType === "radial" && (
+              <div
+                className="relative flex items-center justify-center shrink-0"
+                style={{ width: `${dialSize}px`, height: `${dialSize}px` }}
+                role="progressbar"
+                aria-valuenow={Math.round(pct)}
+                aria-valuemin={min}
+                aria-valuemax={max}
               >
-                {formattedValue}
-              </span>
-              {unit && (
-                <span
-                  className="font-semibold text-base-content/60 mt-1"
-                  style={{ fontSize: `${radialUnitFontSize}px` }}
+                <svg
+                  viewBox="0 0 100 100"
+                  className="w-full h-full transform -rotate-90 overflow-visible"
                 >
-                  {unit}
-                </span>
-              )}
-            </div>
-          </div>
-        )}
-
-        {data.dataType === "number" && gaugeType === "bar" && (
-          <div className="w-full h-full flex flex-col justify-center gap-2 px-1">
-            <div className="flex justify-between items-baseline">
-              <span
-                className="font-bold font-mono text-base-content leading-none"
-                style={{ fontSize: `${barValFontSize}px` }}
-              >
-                {formattedValue}{" "}
-                {unit && (
+                  {/* Background Track Circle */}
+                  <circle
+                    cx="50"
+                    cy="50"
+                    r="40"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="8"
+                    className="text-base-content/10"
+                  />
+                  {/* Animated Progress Fill Arc */}
+                  <circle
+                    cx="50"
+                    cy="50"
+                    r="40"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="8"
+                    strokeLinecap="round"
+                    strokeDasharray="251.327"
+                    strokeDashoffset={251.327 - (pct / 100) * 251.327}
+                    className={`${colorClass} transition-[stroke-dashoffset] duration-500 ease-out`}
+                  />
+                </svg>
+                {/* Center Value Text */}
+                <div className="absolute inset-0 flex flex-col items-center justify-center p-1 text-center leading-none pointer-events-none">
                   <span
-                    className="font-medium text-base-content/60"
+                    className="font-bold font-mono tracking-tight text-base-content"
+                    style={{ fontSize: `${radialValFontSize}px` }}
+                  >
+                    {formattedValue}
+                  </span>
+                  {unit && (
+                    <span
+                      className="font-semibold text-base-content/60 mt-1"
+                      style={{ fontSize: `${radialUnitFontSize}px` }}
+                    >
+                      {unit}
+                    </span>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {data.dataType === "number" && gaugeType === "bar" && (
+              <div className="w-full h-full flex flex-col justify-center gap-2 px-1">
+                <div className="flex justify-between items-baseline">
+                  <span
+                    className="font-bold font-mono text-base-content leading-none"
+                    style={{ fontSize: `${barValFontSize}px` }}
+                  >
+                    {formattedValue}{" "}
+                    {unit && (
+                      <span
+                        className="font-medium text-base-content/60"
+                        style={{ fontSize: `${barSubFontSize}px` }}
+                      >
+                        {unit}
+                      </span>
+                    )}
+                  </span>
+                  <span
+                    className="font-mono text-base-content/50"
                     style={{ fontSize: `${barSubFontSize}px` }}
                   >
-                    {unit}
+                    {Math.round(pct)}%
                   </span>
-                )}
-              </span>
-              <span
-                className="font-mono text-base-content/50"
-                style={{ fontSize: `${barSubFontSize}px` }}
-              >
-                {Math.round(pct)}%
-              </span>
-            </div>
-            <progress
-              className={`progress ${progressClass} w-full rounded-lg transition-all duration-300`}
-              style={{ height: `${barHeight}px` }}
-              value={pct}
-              max="100"
-            />
-            <div
-              className="flex justify-between font-mono text-base-content/50"
-              style={{ fontSize: `${Math.max(9, barSubFontSize * 0.8)}px` }}
-            >
-              <span>{min}</span>
-              <span>{max}</span>
-            </div>
-          </div>
-        )}
-
-        {(gaugeType === "value" || data.dataType !== "number") && (
-          <div className="flex flex-col items-center justify-center gap-1.5 p-1 text-center w-full h-full overflow-hidden">
-            {data.dataType === "boolean" ? (
-              <div
-                className={`inline-flex items-center gap-2.5 rounded-2xl font-mono font-bold tracking-wider uppercase border shadow-sm transition-all duration-300 ${
-                  data.parsedValue
-                    ? "bg-success/15 text-success border-success/40 shadow-success/10"
-                    : "bg-error/15 text-error border-error/40 shadow-error/10"
-                }`}
-                style={{
-                  fontSize: `${cardBadgeFontSize}px`,
-                  padding: `${Math.max(4, Math.round(cardBadgeFontSize * 0.25))}px ${Math.max(12, Math.round(cardBadgeFontSize * 0.6))}px`,
-                }}
-              >
-                <span
-                  className={`rounded-full shrink-0 animate-pulse ${
-                    data.parsedValue
-                      ? "bg-success shadow-[0_0_8px_#22c55e]"
-                      : "bg-error shadow-[0_0_8px_#ef4444]"
-                  }`}
-                  style={{
-                    width: `${Math.max(6, Math.round(cardBadgeFontSize * 0.35))}px`,
-                    height: `${Math.max(6, Math.round(cardBadgeFontSize * 0.35))}px`,
-                  }}
+                </div>
+                <progress
+                  className={`progress ${progressClass} w-full rounded-lg transition-all duration-300`}
+                  style={{ height: `${barHeight}px` }}
+                  value={pct}
+                  max="100"
                 />
-                <span>{formattedValue}</span>
-              </div>
-            ) : (
-              <div className="flex items-baseline gap-1.5 justify-center flex-wrap max-w-full px-2">
-                <span
-                  className="font-bold font-mono text-base-content tracking-tight leading-tight break-words text-center max-w-full"
-                  style={{ fontSize: `${cardValFontSize}px` }}
+                <div
+                  className="flex justify-between font-mono text-base-content/50"
+                  style={{ fontSize: `${Math.max(9, barSubFontSize * 0.8)}px` }}
                 >
-                  {formattedValue}
-                </span>
-                {unit && (
-                  <span
-                    className="font-semibold text-base-content/70 shrink-0"
-                    style={{ fontSize: `${Math.max(11, cardValFontSize * 0.45)}px` }}
+                  <span>{min}</span>
+                  <span>{max}</span>
+                </div>
+              </div>
+            )}
+
+            {(gaugeType === "value" || data.dataType !== "number") && (
+              <div className="flex flex-col items-center justify-center gap-1.5 p-1 text-center w-full h-full overflow-hidden">
+                {data.dataType === "boolean" ? (
+                  <div
+                    className={`inline-flex items-center gap-2.5 rounded-2xl font-mono font-bold tracking-wider uppercase border shadow-sm transition-all duration-300 ${
+                      data.parsedValue
+                        ? "bg-success/15 text-success border-success/40 shadow-success/10"
+                        : "bg-error/15 text-error border-error/40 shadow-error/10"
+                    }`}
+                    style={{
+                      fontSize: `${cardBadgeFontSize}px`,
+                      padding: `${Math.max(4, Math.round(cardBadgeFontSize * 0.25))}px ${Math.max(12, Math.round(cardBadgeFontSize * 0.6))}px`,
+                    }}
                   >
-                    {unit}
-                  </span>
+                    <span
+                      className={`rounded-full shrink-0 animate-pulse ${
+                        data.parsedValue
+                          ? "bg-success shadow-[0_0_8px_#22c55e]"
+                          : "bg-error shadow-[0_0_8px_#ef4444]"
+                      }`}
+                      style={{
+                        width: `${Math.max(6, Math.round(cardBadgeFontSize * 0.35))}px`,
+                        height: `${Math.max(6, Math.round(cardBadgeFontSize * 0.35))}px`,
+                      }}
+                    />
+                    <span>{formattedValue}</span>
+                  </div>
+                ) : (
+                  <div className="flex items-baseline gap-1.5 justify-center flex-wrap max-w-full px-2">
+                    <span
+                      className="font-bold font-mono text-base-content tracking-tight leading-tight break-words text-center max-w-full"
+                      style={{ fontSize: `${cardValFontSize}px` }}
+                    >
+                      {formattedValue}
+                    </span>
+                    {unit && (
+                      <span
+                        className="font-semibold text-base-content/70 shrink-0"
+                        style={{
+                          fontSize: `${Math.max(11, cardValFontSize * 0.45)}px`,
+                        }}
+                      >
+                        {unit}
+                      </span>
+                    )}
+                  </div>
                 )}
               </div>
             )}
           </div>
-        )}
-      </div>
 
-      {/* Footer Meta */}
-      <div className="flex items-center justify-between text-[10px] text-base-content/50 pt-1.5 border-t border-base-200">
-        <div className="flex items-center gap-1">
-          <RiTimeLine className="text-xs" />
-          <span>{formatTime(data.receivedAt)}</span>
-        </div>
-      </div>
-    </>
+          {/* Footer Meta */}
+          <div className="flex items-center justify-between text-[10px] text-base-content/50 pt-1.5 border-t border-base-200">
+            <div className="flex items-center gap-1">
+              <RiTimeLine className="text-xs" />
+              <span>{formatTime(data.receivedAt)}</span>
+            </div>
+          </div>
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/panels/ImagePanel.tsx
+++ b/frontend/src/components/panels/ImagePanel.tsx
@@ -67,148 +67,148 @@ export function ImageConfigModal({ config, onSave, onClose }: ModalProps) {
       saveDisabled={uploading}
     >
       <div role="tablist" className="tabs tabs-box mb-4">
-          <a
-            role="tab"
-            className={`tab flex-1 ${tab === "url" ? "tab-active" : ""}`}
-            onClick={() => setTab("url")}
-          >
-            URL
-          </a>
-          <a
-            role="tab"
-            className={`tab flex-1 ${tab === "upload" ? "tab-active" : ""}`}
-            onClick={() => setTab("upload")}
-          >
-            Upload
-          </a>
-          <a
-            role="tab"
-            className={`tab flex-1 ${tab === "presets" ? "tab-active" : ""}`}
-            onClick={() => setTab("presets")}
-          >
-            Presets
-          </a>
-        </div>
+        <a
+          role="tab"
+          className={`tab flex-1 ${tab === "url" ? "tab-active" : ""}`}
+          onClick={() => setTab("url")}
+        >
+          URL
+        </a>
+        <a
+          role="tab"
+          className={`tab flex-1 ${tab === "upload" ? "tab-active" : ""}`}
+          onClick={() => setTab("upload")}
+        >
+          Upload
+        </a>
+        <a
+          role="tab"
+          className={`tab flex-1 ${tab === "presets" ? "tab-active" : ""}`}
+          onClick={() => setTab("presets")}
+        >
+          Presets
+        </a>
+      </div>
 
-        {tab === "url" && (
-          <fieldset className="fieldset">
-            <legend className="fieldset-legend">Image URL</legend>
+      {tab === "url" && (
+        <fieldset className="fieldset">
+          <legend className="fieldset-legend">Image URL</legend>
+          <input
+            className="input input-bordered w-full"
+            placeholder="https://example.com/image.png"
+            value={src}
+            onChange={(e) => setSrc(e.target.value)}
+          />
+          <p className="fieldset-label">Paste a direct link to an image.</p>
+        </fieldset>
+      )}
+
+      {tab === "upload" && (
+        <fieldset className="fieldset">
+          <legend className="fieldset-legend">Upload a file</legend>
+          <label
+            className={`flex flex-col items-center justify-center gap-1 rounded-box border-2 border-dashed p-7 text-center cursor-pointer transition-colors ${
+              dragOver
+                ? "border-primary bg-primary/5"
+                : "border-base-300 hover:border-base-content/30"
+            }`}
+            onDragOver={(e) => {
+              e.preventDefault();
+              setDragOver(true);
+            }}
+            onDragLeave={() => setDragOver(false)}
+            onDrop={(e) => {
+              e.preventDefault();
+              setDragOver(false);
+              const file = e.dataTransfer.files?.[0];
+              if (file) void handleUpload(file);
+            }}
+          >
             <input
-              className="input input-bordered w-full"
-              placeholder="https://example.com/image.png"
-              value={src}
-              onChange={(e) => setSrc(e.target.value)}
-            />
-            <p className="fieldset-label">Paste a direct link to an image.</p>
-          </fieldset>
-        )}
-
-        {tab === "upload" && (
-          <fieldset className="fieldset">
-            <legend className="fieldset-legend">Upload a file</legend>
-            <label
-              className={`flex flex-col items-center justify-center gap-1 rounded-box border-2 border-dashed p-7 text-center cursor-pointer transition-colors ${
-                dragOver
-                  ? "border-primary bg-primary/5"
-                  : "border-base-300 hover:border-base-content/30"
-              }`}
-              onDragOver={(e) => {
-                e.preventDefault();
-                setDragOver(true);
-              }}
-              onDragLeave={() => setDragOver(false)}
-              onDrop={(e) => {
-                e.preventDefault();
-                setDragOver(false);
-                const file = e.dataTransfer.files?.[0];
+              type="file"
+              className="hidden"
+              accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
+              disabled={uploading}
+              onChange={(e) => {
+                const file = e.target.files?.[0];
                 if (file) void handleUpload(file);
               }}
+            />
+            <span className="text-sm font-medium text-base-content/70">
+              {uploading
+                ? "Uploading…"
+                : "Drop an image here, or click to browse"}
+            </span>
+            <span className="text-xs text-base-content/40">
+              PNG, JPG, GIF, WebP, SVG
+            </span>
+          </label>
+          {error && <span className="text-xs text-error mt-1">{error}</span>}
+        </fieldset>
+      )}
+
+      {tab === "presets" && (
+        <fieldset className="fieldset">
+          <legend className="fieldset-legend">Previously uploaded</legend>
+          {presets.length > 0 ? (
+            <div className="grid grid-cols-3 gap-2">
+              {presets.map((p) => (
+                <button
+                  key={p.name}
+                  type="button"
+                  title={p.name}
+                  className={`relative border-2 rounded-box overflow-hidden aspect-4/3 ${src === p.url ? "border-primary" : "border-base-300"}`}
+                  onClick={() => setSrc(p.url)}
+                >
+                  <img
+                    src={p.url}
+                    alt={p.name}
+                    className="w-full h-full object-cover"
+                  />
+                  <span className="absolute inset-x-0 bottom-0 bg-linear-to-t from-black/75 to-transparent text-white text-[10px] px-1.5 pt-2.5 pb-1 truncate">
+                    {p.name}
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-8 text-base-content/40">
+              <p className="text-sm font-medium">No uploads yet</p>
+              <p className="text-xs mt-1">
+                Images you upload will show up here for reuse
+              </p>
+            </div>
+          )}
+        </fieldset>
+      )}
+
+      <div className="mt-4">
+        <div className="flex items-center justify-between mb-2">
+          <span className="fieldset-legend">Preview</span>
+          {src && (
+            <button
+              type="button"
+              className="link link-hover text-xs text-base-content/60"
+              onClick={() => setSrc("")}
             >
-              <input
-                type="file"
-                className="hidden"
-                accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
-                disabled={uploading}
-                onChange={(e) => {
-                  const file = e.target.files?.[0];
-                  if (file) void handleUpload(file);
-                }}
-              />
-              <span className="text-sm font-medium text-base-content/70">
-                {uploading
-                  ? "Uploading…"
-                  : "Drop an image here, or click to browse"}
-              </span>
-              <span className="text-xs text-base-content/40">
-                PNG, JPG, GIF, WebP, SVG
-              </span>
-            </label>
-            {error && <span className="text-xs text-error mt-1">{error}</span>}
-          </fieldset>
-        )}
-
-        {tab === "presets" && (
-          <fieldset className="fieldset">
-            <legend className="fieldset-legend">Previously uploaded</legend>
-            {presets.length > 0 ? (
-              <div className="grid grid-cols-3 gap-2">
-                {presets.map((p) => (
-                  <button
-                    key={p.name}
-                    type="button"
-                    title={p.name}
-                    className={`relative border-2 rounded-box overflow-hidden aspect-4/3 ${src === p.url ? "border-primary" : "border-base-300"}`}
-                    onClick={() => setSrc(p.url)}
-                  >
-                    <img
-                      src={p.url}
-                      alt={p.name}
-                      className="w-full h-full object-cover"
-                    />
-                    <span className="absolute inset-x-0 bottom-0 bg-linear-to-t from-black/75 to-transparent text-white text-[10px] px-1.5 pt-2.5 pb-1 truncate">
-                      {p.name}
-                    </span>
-                  </button>
-                ))}
-              </div>
-            ) : (
-              <div className="text-center py-8 text-base-content/40">
-                <p className="text-sm font-medium">No uploads yet</p>
-                <p className="text-xs mt-1">
-                  Images you upload will show up here for reuse
-                </p>
-              </div>
-            )}
-          </fieldset>
-        )}
-
-        <div className="mt-4">
-          <div className="flex items-center justify-between mb-2">
-            <span className="fieldset-legend">Preview</span>
-            {src && (
-              <button
-                type="button"
-                className="link link-hover text-xs text-base-content/60"
-                onClick={() => setSrc("")}
-              >
-                Clear
-              </button>
-            )}
-          </div>
-          <div className="border border-base-300 rounded-box p-2 h-32 flex items-center justify-center">
-            {src ? (
-              <img
-                src={src}
-                alt="preview"
-                className="max-h-full max-w-full object-contain"
-              />
-            ) : (
-              <span className="text-xs text-base-content/40">
-                No image selected
-              </span>
-            )}
-          </div>
+              Clear
+            </button>
+          )}
         </div>
+        <div className="border border-base-300 rounded-box p-2 h-32 flex items-center justify-center">
+          {src ? (
+            <img
+              src={src}
+              alt="preview"
+              className="max-h-full max-w-full object-contain"
+            />
+          ) : (
+            <span className="text-xs text-base-content/40">
+              No image selected
+            </span>
+          )}
+        </div>
+      </div>
     </PanelModalFrame>
   );
 }

--- a/frontend/src/components/panels/InputPanel.tsx
+++ b/frontend/src/components/panels/InputPanel.tsx
@@ -51,10 +51,7 @@ export function InputConfigModal({
       title="Input Configuration"
       onClose={onClose}
       onSave={() =>
-        onSave(
-          { topic, qos, retain },
-          selectedBrokerId || defaultBrokerId,
-        )
+        onSave({ topic, qos, retain }, selectedBrokerId || defaultBrokerId)
       }
       saveDisabled={
         brokerStatuses.length === 0 || !topic.trim() || hasWildcardWarning
@@ -121,7 +118,9 @@ export default function InputPanel({
         .filter(Boolean)
     : [];
 
-  const hasWildcard = parsedTopics.some((t) => t.includes("+") || t.includes("#"));
+  const hasWildcard = parsedTopics.some(
+    (t) => t.includes("+") || t.includes("#"),
+  );
 
   const handlePublish = async () => {
     if (parsedTopics.length === 0 || hasWildcard) return;
@@ -175,7 +174,9 @@ export default function InputPanel({
         }`}
         onClick={handlePublish}
         disabled={loading || parsedTopics.length === 0 || !value || hasWildcard}
-        title={hasWildcard ? "Cannot publish to wildcard topics (+ or #)" : undefined}
+        title={
+          hasWildcard ? "Cannot publish to wildcard topics (+ or #)" : undefined
+        }
       >
         {loading ? (
           <span className="loading loading-spinner loading-xs" />

--- a/frontend/src/components/panels/LogPanel.test.tsx
+++ b/frontend/src/components/panels/LogPanel.test.tsx
@@ -146,13 +146,7 @@ describe("LogPanel", () => {
   });
 
   it("shows empty state placeholder when no topic is configured", () => {
-    render(
-      <LogPanel
-        panelId="panel-1"
-        brokerId="b1"
-        config={{}}
-      />,
-    );
+    render(<LogPanel panelId="panel-1" brokerId="b1" config={{}} />);
 
     expect(
       screen.getByText("No topic configured — open settings to add topic"),

--- a/frontend/src/components/panels/LogPanel.tsx
+++ b/frontend/src/components/panels/LogPanel.tsx
@@ -148,7 +148,9 @@ export function LogConfigModal({
               key={label}
               className="flex items-center justify-between cursor-pointer p-2.5 rounded-lg border border-base-300 bg-base-200/40"
             >
-              <span className="text-xs font-medium text-base-content/80">{label}</span>
+              <span className="text-xs font-medium text-base-content/80">
+                {label}
+              </span>
               <input
                 type="checkbox"
                 className="toggle toggle-xs toggle-primary"

--- a/frontend/src/components/panels/MqttOptionsSection.tsx
+++ b/frontend/src/components/panels/MqttOptionsSection.tsx
@@ -1,5 +1,9 @@
 import { useState } from "react";
-import { RiSettings3Line, RiArrowRightSLine, RiArrowDownSLine } from "react-icons/ri";
+import {
+  RiSettings3Line,
+  RiArrowRightSLine,
+  RiArrowDownSLine,
+} from "react-icons/ri";
 
 interface Props {
   qos: number;

--- a/frontend/src/components/panels/PanelModalFrame.tsx
+++ b/frontend/src/components/panels/PanelModalFrame.tsx
@@ -52,11 +52,7 @@ export default function PanelModalFrame({
         <div className="space-y-4">{children}</div>
 
         <div className="modal-action">
-          <button
-            type="button"
-            className="btn btn-sm"
-            onClick={onClose}
-          >
+          <button type="button" className="btn btn-sm" onClick={onClose}>
             {cancelLabel}
           </button>
           {onSave && (

--- a/frontend/src/components/panels/definitions.tsx
+++ b/frontend/src/components/panels/definitions.tsx
@@ -11,10 +11,7 @@ import {
 } from "react-icons/md";
 import { api } from "../../api/client";
 import type { PanelDefinition } from "./types";
-import GaugePanel, {
-  GaugeConfigModal,
-  type GaugeConfig,
-} from "./GaugePanel";
+import GaugePanel, { GaugeConfigModal, type GaugeConfig } from "./GaugePanel";
 import LogPanel, { LogConfigModal, type LogConfig } from "./LogPanel";
 import BrokerStatsPanel, {
   BrokerStatsConfigModal,
@@ -24,20 +21,14 @@ import ButtonPanel, {
   ButtonConfigModal,
   type ButtonConfig,
 } from "./ButtonPanel";
-import InputPanel, {
-  InputConfigModal,
-  type InputConfig,
-} from "./InputPanel";
+import InputPanel, { InputConfigModal, type InputConfig } from "./InputPanel";
 import CronPanel, { CronConfigModal, type CronConfig } from "./CronPanel";
 import TextPanel, { TextConfigModal, type TextConfig } from "./TextPanel";
 import SeparatorPanel, {
   SeparatorConfigModal,
   type SeparatorConfig,
 } from "./SeparatorPanel";
-import ImagePanel, {
-  ImageConfigModal,
-  type ImageConfig,
-} from "./ImagePanel";
+import ImagePanel, { ImageConfigModal, type ImageConfig } from "./ImagePanel";
 
 export const gaugePanelDefinition: PanelDefinition<GaugeConfig> = {
   type: "gauge",

--- a/frontend/src/components/panels/gaugeUtils.ts
+++ b/frontend/src/components/panels/gaugeUtils.ts
@@ -4,7 +4,10 @@ export interface ParsedResult {
   raw: string;
 }
 
-export function parseGaugePayload(payload: string, valueKey?: string): ParsedResult {
+export function parseGaugePayload(
+  payload: string,
+  valueKey?: string,
+): ParsedResult {
   const raw = payload;
   let target: unknown = payload;
 
@@ -34,7 +37,11 @@ export function parseGaugePayload(payload: string, valueKey?: string): ParsedRes
     const trimmed = target.trim();
 
     const lower = trimmed.toLowerCase();
-    if (["true", "false", "on", "off", "yes", "no", "online", "offline"].includes(lower)) {
+    if (
+      ["true", "false", "on", "off", "yes", "no", "online", "offline"].includes(
+        lower,
+      )
+    ) {
       const isTrue = ["true", "on", "yes", "online"].includes(lower);
       return { parsedValue: isTrue, dataType: "boolean", raw };
     }

--- a/frontend/src/components/panels/index.ts
+++ b/frontend/src/components/panels/index.ts
@@ -28,5 +28,3 @@ export * from "./definitions";
 export { default as PanelPreviewCard } from "./PanelPreviewCard";
 export { default as PanelEmptyState } from "./PanelEmptyState";
 export { default as PanelModalFrame } from "./PanelModalFrame";
-
-

--- a/frontend/src/components/panels/registry.test.tsx
+++ b/frontend/src/components/panels/registry.test.tsx
@@ -139,8 +139,12 @@ describe("Registry Helper: defaultValidateConfig & defaultValidateWarning", () =
     };
 
     expect(defaultValidateConfig(customDef, {}).isValid).toBe(false);
-    expect(defaultValidateConfig(customDef, {}).warning).toBe("API Key required");
-    expect(defaultValidateConfig(customDef, { apiKey: "secret" }).isValid).toBe(true);
+    expect(defaultValidateConfig(customDef, {}).warning).toBe(
+      "API Key required",
+    );
+    expect(defaultValidateConfig(customDef, { apiKey: "secret" }).isValid).toBe(
+      true,
+    );
   });
 });
 
@@ -166,7 +170,9 @@ describe("Registry Helper: defaultCheckEmpty", () => {
     expect(empty?.message).toContain("No image");
     expect(empty?.actionLabel).toBe("Choose Image");
 
-    expect(defaultCheckEmpty(imageDef, { src: "https://example.com/logo.png" })).toBeNull();
+    expect(
+      defaultCheckEmpty(imageDef, { src: "https://example.com/logo.png" }),
+    ).toBeNull();
   });
 
   it("detects empty state for unconfigured Input panel", () => {
@@ -174,7 +180,9 @@ describe("Registry Helper: defaultCheckEmpty", () => {
     expect(empty).toBeDefined();
     expect(empty?.message).toContain("No topic configured");
 
-    expect(defaultCheckEmpty(inputDef, { topic: "devices/command" })).toBeNull();
+    expect(
+      defaultCheckEmpty(inputDef, { topic: "devices/command" }),
+    ).toBeNull();
   });
 
   it("detects empty state for unconfigured Cron panel", () => {
@@ -196,7 +204,9 @@ describe("Registry Helper: defaultBuildHeaderMeta", () => {
   const textDef = getPanelDefinition("text")!;
 
   it("formats single topic summary", () => {
-    const meta = defaultBuildHeaderMeta(buttonDef, { topic: "home/living/temp" });
+    const meta = defaultBuildHeaderMeta(buttonDef, {
+      topic: "home/living/temp",
+    });
     expect(meta.topicSummary).toBe("home/living/temp");
   });
 
@@ -210,7 +220,9 @@ describe("Registry Helper: defaultBuildHeaderMeta", () => {
       topics: "sensor/temp, sensor/humidity, sensor/pressure",
     });
     expect(meta.topicSummary).toBe("3 configured");
-    expect(meta.topicDetail).toBe("sensor/temp, sensor/humidity, sensor/pressure");
+    expect(meta.topicDetail).toBe(
+      "sensor/temp, sensor/humidity, sensor/pressure",
+    );
   });
 
   it("includes payload preview for control category panels", () => {
@@ -232,19 +244,21 @@ describe("Registry Helper: defaultBuildHeaderMeta", () => {
 describe("Registry Helper: defaultResolvePickedTopic & Custom Resolve", () => {
   it("replaces topic when existing topic is empty", () => {
     expect(defaultResolvePickedTopic("", "sensor/temp")).toBe("sensor/temp");
-    expect(defaultResolvePickedTopic(undefined, "sensor/temp")).toBe("sensor/temp");
+    expect(defaultResolvePickedTopic(undefined, "sensor/temp")).toBe(
+      "sensor/temp",
+    );
   });
 
   it("merges multiple topics uniquely", () => {
-    expect(
-      defaultResolvePickedTopic("sensor/a, sensor/b", "sensor/c"),
-    ).toBe("sensor/a, sensor/b, sensor/c");
+    expect(defaultResolvePickedTopic("sensor/a, sensor/b", "sensor/c")).toBe(
+      "sensor/a, sensor/b, sensor/c",
+    );
   });
 
   it("does not duplicate already existing topic in list", () => {
-    expect(
-      defaultResolvePickedTopic("sensor/a, sensor/b", "sensor/a"),
-    ).toBe("sensor/a, sensor/b");
+    expect(defaultResolvePickedTopic("sensor/a, sensor/b", "sensor/a")).toBe(
+      "sensor/a, sensor/b",
+    );
   });
 
   it("gauge custom resolvePickedTopic replaces rather than merging", () => {
@@ -259,12 +273,16 @@ describe("Separator layout constraints", () => {
   const sepDef = getPanelDefinition("separator")!;
 
   it("applies horizontal height constraint", () => {
-    const constraints = sepDef.getMinMaxConstraints?.({ orientation: "horizontal" });
+    const constraints = sepDef.getMinMaxConstraints?.({
+      orientation: "horizontal",
+    });
     expect(constraints).toEqual({ minW: 1, minH: 1, maxH: 1 });
   });
 
   it("applies vertical width constraint", () => {
-    const constraints = sepDef.getMinMaxConstraints?.({ orientation: "vertical" });
+    const constraints = sepDef.getMinMaxConstraints?.({
+      orientation: "vertical",
+    });
     expect(constraints).toEqual({ minW: 1, minH: 1, maxW: 1 });
   });
 });
@@ -333,7 +351,9 @@ describe("PanelEmptyState", () => {
     );
 
     expect(screen.getByText("No image chosen")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /choose image/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /choose image/i }),
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -397,4 +417,3 @@ describe("PanelModalFrame", () => {
     expect(onSave).not.toHaveBeenCalled();
   });
 });
-

--- a/frontend/src/components/panels/registry.ts
+++ b/frontend/src/components/panels/registry.ts
@@ -12,9 +12,7 @@ export function registerPanel(definition: PanelDefinition): void {
   registry.set(definition.type, definition);
 }
 
-export function getPanelDefinition(
-  type: string,
-): PanelDefinition | undefined {
+export function getPanelDefinition(type: string): PanelDefinition | undefined {
   return registry.get(type);
 }
 
@@ -22,7 +20,9 @@ export function getAllPanels(): PanelDefinition[] {
   return Array.from(registry.values());
 }
 
-export function getPanelsByCategory(category: PanelCategory): PanelDefinition[] {
+export function getPanelsByCategory(
+  category: PanelCategory,
+): PanelDefinition[] {
   return getAllPanels().filter((p) => p.category === category);
 }
 
@@ -77,7 +77,10 @@ export function defaultValidateConfig(
   }
 
   if (def.category === "control") {
-    const topicsList = topic.split(",").map((t) => t.trim()).filter(Boolean);
+    const topicsList = topic
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
     if (topicsList.some((t) => t.includes("+") || t.includes("#"))) {
       return {
         isValid: false,

--- a/frontend/src/data/dashboardTemplates.test.ts
+++ b/frontend/src/data/dashboardTemplates.test.ts
@@ -56,7 +56,7 @@ describe("dashboardTemplates", () => {
               const cell = `${col},${row}`;
               if (occupied.has(cell)) {
                 throw new Error(
-                  `Overlap in template "${template.name}" at cell (${col}, ${row}) between "${occupied.get(cell)}" and "${p.title}"`
+                  `Overlap in template "${template.name}" at cell (${col}, ${row}) between "${occupied.get(cell)}" and "${p.title}"`,
                 );
               }
               occupied.set(cell, p.title);

--- a/frontend/src/data/dashboardTemplates.ts
+++ b/frontend/src/data/dashboardTemplates.ts
@@ -97,7 +97,7 @@ export const DASHBOARD_TEMPLATES: DashboardTemplate[] = [
         config_json: {
           label: "Boost Fan",
           topic: "sensors/bathroom/humidity",
-          payload: "{\n  \"action\": \"boost\"\n}",
+          payload: '{\n  "action": "boost"\n}',
           qos: 0,
           retain: false,
           header_meta_pinned: false,
@@ -323,8 +323,7 @@ export const DASHBOARD_TEMPLATES: DashboardTemplate[] = [
         w: 4,
         h: 2,
         config_json: {
-          topics:
-            "$SYS/broker/log/W, $SYS/broker/log/E, $SYS/broker/clients/#",
+          topics: "$SYS/broker/log/W, $SYS/broker/log/E, $SYS/broker/clients/#",
           maxMessages: 100,
           dateFormat: "time",
           showQos: true,

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -754,7 +754,10 @@ export default function ConfigPage() {
                       <span className="font-medium text-sm">
                         Authentication
                       </span>
-                      <div role="tablist" className="tabs tabs-box tabs-sm grid grid-cols-3 w-full">
+                      <div
+                        role="tablist"
+                        className="tabs tabs-box tabs-sm grid grid-cols-3 w-full"
+                      >
                         {(["none", "password", "certificate"] as const).map(
                           (mode) => {
                             const isCert = mode === "certificate";
@@ -766,7 +769,11 @@ export default function ConfigPage() {
                                 type="button"
                                 aria-disabled={disabled}
                                 className={`tab w-full truncate ${form.auth_mode === mode ? "tab-active" : ""} ${disabled ? "opacity-40 cursor-not-allowed tooltip tooltip-bottom" : ""}`}
-                                data-tip={disabled ? "Requires TLS to be enabled" : undefined}
+                                data-tip={
+                                  disabled
+                                    ? "Requires TLS to be enabled"
+                                    : undefined
+                                }
                                 onClick={() =>
                                   !disabled &&
                                   setForm((prev) => ({

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,7 +5,9 @@ import tailwindcss from "@tailwindcss/vite";
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   define: {
-    "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV ?? "production"),
+    "process.env.NODE_ENV": JSON.stringify(
+      process.env.NODE_ENV ?? "production",
+    ),
     "process.env": {},
     process: { env: {} },
   },


### PR DESCRIPTION
The Frontend CI "Check for Prettier issues" step has never been able to fail.

## The bug

The workflow runs:

```yaml
run: npm run prettier -- --check .
```

but the `prettier` script is `prettier --write .`, so the flags concatenate into:

```
prettier --write . --check .
```

With both flags present `--write` wins: Prettier **rewrites** the files in the CI workspace and exits `0`. The step's log ends with `Code style issues fixed in 24 files` — *fixed*, not *found* — and the job goes green regardless of how much drift exists. ([example run](https://github.com/jmischler72/mqtt-dashboard/actions/runs/33101340033/job/98619533786))

That is why 24 files have quietly drifted out of format on `main`.

## The fix

Two commits, so the mechanical churn is easy to skip:

1. **`chore(ci)`** — adds a dedicated `prettier:check` script (`prettier --check .`) and points the workflow at it. Confirmed locally that it now exits `1` and reports issues *found*.
2. **`style(frontend)`** — formats the 24 drifted files, so the newly-enforcing check passes.

Both are needed together: landing the workflow fix alone would immediately turn `main` red.

## No behaviour change

`tsc -b`, ESLint, `vite build` and the full test suite all pass after formatting.

As a stronger check I diffed the production bundle before and after. It is not byte-identical, and the entire difference is 9 bytes across three JSX sites where a trailing space inside text became an explicit `{" "}` child:

```
- children:[`Waiting for data on `
+ children:[`Waiting for data on`, ` `
```

React renders `["…on ", <span/>]` and `["…on", " ", <span/>]` to identical DOM, so this is a representation change only. The three sites are in `GaugePanel`, `ButtonPanel` and `BrokerTopicSection`.

## Follow-up

Worth considering a `lint-staged`/pre-commit hook so drift is caught before CI, but that is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E12AVJgMLjg8tUa4XEEiwN