### PR TITLE
feat(panels): add slider panel

### DIFF
--- a/frontend/src/components/panels/PayloadBuilder.test.tsx
+++ b/frontend/src/components/panels/PayloadBuilder.test.tsx
@@ -59,6 +59,15 @@ describe("token editor DOM", () => {
     expect(readTemplate(host("<div>a</div><div>b</div>"))).toBe("a\nb");
   });
 
+  it("ignores the filler <br> a browser parks at the end", () => {
+    // Invisible to the user, so publishing the newline it stands for would
+    // append a byte they never typed
+    expect(readTemplate(host("a<br>"))).toBe("a");
+    expect(readTemplate(host("<div>a</div><div>b<br></div>"))).toBe("a\nb");
+    // A blank line the user actually made is still a line
+    expect(readTemplate(host("a<br><br>"))).toBe("a\n");
+  });
+
   it("repainting replaces the previous content rather than appending", () => {
     const el = host();
     paintTemplate(el, `{"a":${VALUE_TOKEN}}`);
@@ -150,6 +159,14 @@ describe("selection in payload coordinates", () => {
       setCaret(el, offset);
       expect(readSelectionOffsets(el)).toEqual({ start: offset, end: offset });
     }
+  });
+
+  it("puts an offset on a chip's leading edge before it, not after", () => {
+    const el = painted(`${VALUE_TOKEN}C`);
+    setCaret(el, 0);
+    expect(readSelectionOffsets(el)).toEqual({ start: 0, end: 0 });
+    setCaret(el, 1);
+    expect(readSelectionOffsets(el)).toEqual({ start: 1, end: 1 });
   });
 
   it("reports nothing when the selection is outside the editor", () => {

--- a/frontend/src/components/panels/PayloadBuilder.test.tsx
+++ b/frontend/src/components/panels/PayloadBuilder.test.tsx
@@ -1,0 +1,252 @@
+import { useState } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import PayloadBuilder from "./PayloadBuilder";
+import { TOKEN_LABEL, VALUE_TOKEN } from "./payloadShape";
+import {
+  TOKEN_ATTR,
+  paintTemplate,
+  readSelectionOffsets,
+  readTemplate,
+  setCaret,
+} from "./tokenEditor";
+
+vi.mock("../../hooks/usePayloadSample", () => ({
+  usePayloadSample: () => ({
+    recent: [],
+    loading: false,
+    payload: null,
+    suggestedPaths: [],
+  }),
+}));
+
+function host(html?: string): HTMLElement {
+  const el = document.createElement("div");
+  if (html !== undefined) el.innerHTML = html;
+  return el;
+}
+
+describe("token editor DOM", () => {
+  it("paints the token as an atomic chip and the rest as text", () => {
+    const el = host();
+    paintTemplate(el, `{"brightness":${VALUE_TOKEN}}`);
+
+    const chips = el.querySelectorAll(`[${TOKEN_ATTR}]`);
+    expect(chips).toHaveLength(1);
+    expect(chips[0].textContent).toBe(TOKEN_LABEL);
+    expect(chips[0].getAttribute("contenteditable")).toBe("false");
+    expect(el.textContent).toBe('{"brightness":value}');
+  });
+
+  it("reads back exactly what was painted", () => {
+    const templates = [
+      `{"brightness":${VALUE_TOKEN}}`,
+      VALUE_TOKEN,
+      "RESET",
+      "",
+      `${VALUE_TOKEN};ON`,
+    ];
+
+    for (const template of templates) {
+      const el = host();
+      paintTemplate(el, template);
+      expect(readTemplate(el)).toBe(template);
+    }
+  });
+
+  it("reads newlines back out of both shapes a browser produces", () => {
+    expect(readTemplate(host("a<br>b"))).toBe("a\nb");
+    expect(readTemplate(host("<div>a</div><div>b</div>"))).toBe("a\nb");
+  });
+
+  it("repainting replaces the previous content rather than appending", () => {
+    const el = host();
+    paintTemplate(el, `{"a":${VALUE_TOKEN}}`);
+    paintTemplate(el, "RESET");
+    expect(readTemplate(el)).toBe("RESET");
+    expect(el.querySelectorAll(`[${TOKEN_ATTR}]`)).toHaveLength(0);
+  });
+});
+
+describe("PayloadBuilder editor", () => {
+  afterEach(cleanup);
+
+  function openEditor(template: string, onTemplateChange = () => {}) {
+    render(
+      <PayloadBuilder
+        template={template}
+        onTemplateChange={onTemplateChange}
+        previews={[{ key: "", value: "50" }]}
+        brokerId="b1"
+        topic="home/lamp"
+      />,
+    );
+    fireEvent.click(screen.getByText(/Edit/));
+    return screen.getByRole("textbox");
+  }
+
+  it("shows the payload with the token as a chip", () => {
+    const box = openEditor(`{"brightness":${VALUE_TOKEN}}`);
+    expect(box.textContent).toBe('{"brightness":value}');
+    expect(box.querySelectorAll(`[${TOKEN_ATTR}]`)).toHaveLength(1);
+  });
+
+  it("reports edits back as a payload string", () => {
+    const onTemplateChange = vi.fn();
+    const box = openEditor(VALUE_TOKEN, onTemplateChange);
+
+    // What the browser leaves behind after typing "C" ahead of the chip
+    box.insertBefore(document.createTextNode("C"), box.firstChild);
+    fireEvent.input(box);
+
+    expect(onTemplateChange).toHaveBeenCalledWith(`C${VALUE_TOKEN}`);
+  });
+});
+
+describe("selection in payload coordinates", () => {
+  function painted(template: string): HTMLElement {
+    const el = document.createElement("div");
+    document.body.append(el);
+    paintTemplate(el, template);
+    return el;
+  }
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  function select(el: HTMLElement, start: number, end: number) {
+    // Place the caret via the editor's own helper, then stretch to `end`
+    setCaret(el, start);
+    const selection = document.getSelection();
+    if (start !== end) {
+      setCaret(el, end);
+      const to = document.getSelection()?.getRangeAt(0);
+      setCaret(el, start);
+      const range = document.getSelection()?.getRangeAt(0);
+      if (range && to) range.setEnd(to.startContainer, to.startOffset);
+      if (range) {
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      }
+    }
+  }
+
+  it("counts the chip as the one character it stands for", () => {
+    const el = painted(`{"b":${VALUE_TOKEN}}`);
+    select(el, 7, 7);
+    expect(readSelectionOffsets(el)).toEqual({ start: 7, end: 7 });
+  });
+
+  it("reads a selection spanning text and chip alike", () => {
+    const el = painted(`{"b":${VALUE_TOKEN}}`);
+    select(el, 5, 6);
+    expect(readSelectionOffsets(el)).toEqual({ start: 5, end: 6 });
+  });
+
+  it("round-trips a caret through set and read", () => {
+    const el = painted('{"brightness":128}');
+    for (const offset of [0, 5, 14, 18]) {
+      setCaret(el, offset);
+      expect(readSelectionOffsets(el)).toEqual({ start: offset, end: offset });
+    }
+  });
+
+  it("reports nothing when the selection is outside the editor", () => {
+    const el = painted("abc");
+    const outside = document.createElement("div");
+    outside.textContent = "elsewhere";
+    document.body.append(outside);
+    const range = document.createRange();
+    range.selectNodeContents(outside);
+    const selection = document.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    expect(readSelectionOffsets(el)).toBeNull();
+  });
+});
+
+describe("moving and deleting the chip", () => {
+  afterEach(cleanup);
+
+  function Harness({ initial }: { initial: string }) {
+    const [template, setTemplate] = useState(initial);
+    return (
+      <PayloadBuilder
+        template={template}
+        onTemplateChange={setTemplate}
+        previews={[{ key: "", value: "50" }]}
+        brokerId="b1"
+        topic="home/lamp"
+      />
+    );
+  }
+
+  function open(initial: string) {
+    render(<Harness initial={initial} />);
+    fireEvent.click(screen.getByText(/Edit/));
+    return screen.getByRole("textbox");
+  }
+
+  function selectRange(box: HTMLElement, start: number, end: number) {
+    setCaret(box, end);
+    const to = document.getSelection()?.getRangeAt(0);
+    setCaret(box, start);
+    const range = document.getSelection()?.getRangeAt(0);
+    if (range && to) range.setEnd(to.startContainer, to.startOffset);
+  }
+
+  const drop = () =>
+    fireEvent.mouseDown(screen.getByText(/value$/, { selector: "button" }));
+
+  it("hands back the text the chip replaced when it moves on", () => {
+    const box = open('{"b":128}');
+    selectRange(box, 5, 8);
+    drop();
+    expect(readTemplate(box)).toBe(`{"b":${VALUE_TOKEN}}`);
+
+    // Move it to the end: the 128 it covered belongs back where it was
+    setCaret(box, 7);
+    drop();
+    expect(readTemplate(box)).toBe(`{"b":128}${VALUE_TOKEN}`);
+  });
+
+  it("leaves nothing behind when the chip was dropped on empty space", () => {
+    const box = open('{"b":}');
+    setCaret(box, 5);
+    drop();
+    expect(readTemplate(box)).toBe(`{"b":${VALUE_TOKEN}}`);
+
+    setCaret(box, 7);
+    drop();
+    expect(readTemplate(box)).toBe(`{"b":}${VALUE_TOKEN}`);
+  });
+
+  it("removing the chip leaves what it covered, not the demo value", () => {
+    const box = open('{"b":128}');
+    selectRange(box, 5, 8);
+    drop();
+    expect(readTemplate(box)).toBe(`{"b":${VALUE_TOKEN}}`);
+
+    fireEvent.click(screen.getByText(/✕/));
+    expect(readTemplate(box)).toBe('{"b":128}');
+  });
+
+  it("removing a chip that covered nothing leaves nothing", () => {
+    const box = open('{"b":}');
+    setCaret(box, 5);
+    drop();
+    expect(readTemplate(box)).toBe(`{"b":${VALUE_TOKEN}}`);
+
+    fireEvent.click(screen.getByText(/✕/));
+    expect(readTemplate(box)).toBe('{"b":}');
+  });
+
+  it("reads an emptied chip as deleted, husk and all", () => {
+    const box = open(`{"b":${VALUE_TOKEN}}`);
+    // What a browser can leave behind when the chip is backspaced away
+    const chip = box.querySelector(`[${TOKEN_ATTR}]`) as HTMLElement;
+    chip.textContent = "";
+    expect(readTemplate(box)).toBe('{"b":}');
+  });
+});

--- a/frontend/src/components/panels/PayloadBuilder.tsx
+++ b/frontend/src/components/panels/PayloadBuilder.tsx
@@ -1,0 +1,471 @@
+import { useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import {
+  RiErrorWarningLine as WarningIcon,
+  RiEyeLine as PreviewIcon,
+} from "react-icons/ri";
+import { usePayloadSample } from "../../hooks/usePayloadSample";
+import {
+  paintTemplate,
+  readSelectionOffsets,
+  readTemplate,
+  setCaret,
+} from "./tokenEditor";
+import {
+  TOKEN_LABEL,
+  VALUE_TOKEN,
+  clearToken,
+  findLiterals,
+  hasToken,
+  markLiteral,
+  payloadIssue,
+  placeToken,
+  readValue,
+  renderPayload,
+} from "./payloadShape";
+
+/** The payload box, dressed as the textarea it used to be. */
+const editorClass =
+  "textarea textarea-bordered w-full font-mono text-xs leading-relaxed " +
+  "break-all whitespace-pre-wrap cursor-text";
+
+/** One thing the panel can publish, shown as a preview row. */
+export interface PayloadPreview {
+  /** Row label — "On", "Off", "At 72", "07:00", "Sends". */
+  key: string;
+  /** Value substituted for the token; empty for panels with no runtime value. */
+  value: string;
+}
+
+interface Props {
+  /** The literal payload, with at most one token in it. */
+  template: string;
+  onTemplateChange: (template: string) => void;
+  previews: PayloadPreview[];
+  /**
+   * False for panels with no runtime value (button, cron): a token there would
+   * publish an empty hole, so it is flagged rather than offered.
+   */
+  acceptsToken?: boolean;
+  brokerId: string;
+  /** Topic sampled for the "messages your device sent" list. */
+  topic: string;
+  /**
+   * "write" describes the payload to publish; "read" describes the shape of
+   * incoming messages, where the token marks the value to pull out instead of
+   * the value to drop in.
+   */
+  mode?: "write" | "read";
+  /**
+   * One line telling the user what the preview block is showing them, e.g.
+   * "Move the handle to see what the slider publishes at that position."
+   * Defaults to a description of the panel's own kind of publish.
+   */
+  previewNote?: string;
+  /** Panel-specific controls (toggle's On/Off, slider's drag preview). */
+  children?: ReactNode;
+}
+
+/**
+ * The payload editor: the box holds the bytes that get published, verbatim, and
+ * the single token marks the one spot the panel's own value drops into.
+ *
+ * There are no formats or modes to choose between — a device that wants
+ * `{"brightness":128}` is configured by typing that and marking the 128. The
+ * token's position is also where the value is read back from, so the shape is
+ * described once for both directions.
+ */
+export default function PayloadBuilder({
+  template,
+  onTemplateChange,
+  previews,
+  acceptsToken = true,
+  brokerId,
+  topic,
+  mode = "write",
+  previewNote,
+  children,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [samplesOpen, setSamplesOpen] = useState(false);
+  // The constant a marked value held, handed back when the token moves on
+  const [previous, setPrevious] = useState<string | null>(null);
+  const [usedSample, setUsedSample] = useState<number | null>(null);
+  const editorRef = useRef<HTMLDivElement>(null);
+  // What the box currently shows. Repainting on every keystroke would drop the
+  // caret, so the DOM is only rewritten when the template changed elsewhere —
+  // a sample being used, or the token being moved by a chip below.
+  const painted = useRef<string | null>(null);
+
+  /**
+   * Drop the chip where the user is pointing: at the caret, or over whatever
+   * they have selected. This is what makes the token placeable anywhere —
+   * inside a JSON value, in the middle of a word, in a format nothing here can
+   * parse — rather than only onto values the editor managed to recognise.
+   */
+  const dropToken = () => {
+    const host = editorRef.current;
+    if (!host) return;
+
+    // No caret in the box yet: the end of the payload is the honest guess
+    const at = readSelectionOffsets(host) ?? {
+      start: template.length,
+      end: template.length,
+    };
+
+    // Whatever this drop covers is what a later move hands back: the text the
+    // user actually replaced. Handing back the panel's demo value instead is
+    // what used to silt the payload up with copies of it on repeated taps.
+    const covered = template.slice(at.start, at.end);
+    const placed = placeToken(template, at.start, at.end, previous ?? "");
+    setPrevious(covered || null);
+
+    paintTemplate(host, placed.template);
+    painted.current = placed.template;
+    host.focus();
+    setCaret(host, placed.caret);
+
+    // Dropping the chip where it already is changes nothing but the caret
+    if (placed.template !== template) onTemplateChange(placed.template);
+  };
+
+  const handleInput = () => {
+    const host = editorRef.current;
+    if (!host) return;
+    const next = readTemplate(host);
+    painted.current = next;
+    onTemplateChange(next);
+  };
+
+  const {
+    recent,
+    loading,
+    payload: latest,
+  } = usePayloadSample(brokerId, topic);
+  const reading = mode === "read";
+
+  useEffect(() => {
+    const host = editorRef.current;
+    if (!host) {
+      // Closed: the next open starts from a fresh, unpainted box
+      painted.current = null;
+      return;
+    }
+    if (painted.current === template) return;
+    paintTemplate(host, template);
+    painted.current = template;
+  }, [template, open]);
+
+  const tokenPresent = hasToken(template);
+  const literals = acceptsToken ? findLiterals(template) : [];
+  // The spot the chip leaves gets back exactly what the chip covered, and
+  // nothing if it covered nothing. The panel's demo value is for the preview
+  // only — dropping it into the payload writes bytes the user never typed.
+  const restore = previous ?? "";
+
+  const rendered = previews.map((p) => ({
+    ...p,
+    bytes: renderPayload(template, p.value),
+  }));
+
+  // Two states show both sets of real bytes, since the difference between them
+  // is the point. A single state shows the payload as written, mark included —
+  // substituting the demo value would read as if that value were the payload.
+  const summary = (
+    reading || tokenPresent
+      ? rendered.length > 1
+        ? `${rendered[0].bytes}  /  ${rendered[1].bytes}`
+        : template
+      : (rendered[0]?.bytes ?? template)
+  )
+    .split("\n")
+    .join(" ")
+    .replace(/\s+/g, " ");
+
+  // A payload with its token missing — or one in a panel that has no value to
+  // put there — is a broken panel, so it is called out on the collapsed row the
+  // same way an unset topic is, by the same check that holds Save shut.
+  const issue = payloadIssue({ template, acceptsToken, mode });
+  const misconfigured = issue !== null;
+
+  const defaultNote = reading
+    ? "What the panel pulls out of the latest message on this topic."
+    : !acceptsToken
+      ? "The exact bytes published every time this panel fires."
+      : previews.length > 1
+        ? "The exact bytes published in each state."
+        : "The exact bytes published, with the panel's value dropped in.";
+
+  const handleMark = (index: number) => {
+    const result = markLiteral(template, literals[index], restore);
+    setPrevious(result.previous);
+    onTemplateChange(result.template);
+  };
+
+  return (
+    <fieldset className="fieldset p-0 border-0 min-w-0 grid-cols-[minmax(0,1fr)]">
+      {/* Collapsed row — a setting with a value, sitting with Label and Topic */}
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-xs font-medium text-base-content/80 w-14 shrink-0">
+          {reading ? "Reads" : "Payload"}
+        </span>
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          className={`flex-1 min-w-0 flex items-center gap-2 px-2.5 h-8 rounded-lg border bg-base-200/40 text-left cursor-pointer ${
+            open
+              ? "border-primary"
+              : misconfigured
+                ? "border-warning"
+                : "border-base-300"
+          }`}
+        >
+          <span className="font-mono text-xs truncate min-w-0">
+            {summary
+              ? // The same chip the editor shows, so the folded row and the
+                // open one describe the payload the same way
+                summary.split(VALUE_TOKEN).map((chunk, index) => (
+                  <span key={index}>
+                    {index > 0 && (
+                      <span className="mx-0.5 px-1.5 rounded-full border border-primary bg-primary/15 text-primary">
+                        {TOKEN_LABEL}
+                      </span>
+                    )}
+                    {chunk}
+                  </span>
+                ))
+              : "not configured"}
+          </span>
+          <span className="ml-auto shrink-0 text-[11px] font-medium text-primary">
+            {open ? "Close ▴" : "Edit ▾"}
+          </span>
+        </button>
+      </div>
+
+      {/* Same alert the topic field raises when it is left unusable. Kept
+          visible while the editor is open too, since it is also the reason the
+          modal's Save button is off. */}
+      {misconfigured && (
+        <div
+          role="alert"
+          className="alert alert-warning py-1.5 px-3 text-xs mt-2 font-medium flex items-center gap-2"
+        >
+          <WarningIcon className="text-sm shrink-0" />
+          <span>{issue}</span>
+        </div>
+      )}
+
+      {open && (
+        <div className="mt-2 pl-3 border-l-2 border-primary flex flex-col gap-2.5 min-w-0">
+          {/* Start from something the device really sent, rather than typing
+              the shape from memory. Collapsed by default: it is an offer, not
+              a step. */}
+          {recent.length > 0 && (
+            <div
+              className={`rounded-lg border bg-base-200/40 overflow-hidden ${
+                samplesOpen ? "border-base-content/20" : "border-base-300"
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => setSamplesOpen(!samplesOpen)}
+                className="w-full flex items-center gap-2 px-2.5 py-2 text-left cursor-pointer"
+              >
+                <span
+                  className={`shrink-0 w-3.5 text-[10px] text-base-content/60 transition-transform ${
+                    samplesOpen ? "rotate-90" : ""
+                  }`}
+                >
+                  ▶
+                </span>
+                <span className="text-[11.5px] font-medium">
+                  Start from a message this device sent
+                </span>
+                <span className="ml-auto shrink-0 inline-flex items-center gap-1.5 h-5 px-2 rounded-full bg-base-100 border border-base-300 font-mono text-[10.5px] text-base-content/60">
+                  <span className="w-1.5 h-1.5 rounded-full bg-success" />
+                  {recent.length}
+                </span>
+              </button>
+
+              {samplesOpen && (
+                <div className="border-t border-base-300">
+                  {recent.map((message, index) => {
+                    const inUse = index === usedSample;
+                    return (
+                      <button
+                        key={index}
+                        type="button"
+                        onClick={() => {
+                          onTemplateChange(message.payload);
+                          setPrevious(null);
+                          setUsedSample(index);
+                        }}
+                        className={`w-full min-w-0 flex items-start gap-2.5 pl-3 pr-2.5 py-2 border-b border-base-300 text-left cursor-pointer ${
+                          inUse ? "bg-primary/10" : ""
+                        }`}
+                      >
+                        <span className="shrink-0 w-9 pt-px text-[10.5px] font-medium text-base-content/40">
+                          {message.ago}
+                        </span>
+                        <span
+                          className={`flex-1 min-w-0 font-mono text-[11.5px] leading-relaxed break-all ${
+                            inUse ? "" : "text-base-content/80"
+                          }`}
+                        >
+                          {message.payload}
+                        </span>
+                        <span
+                          className={`shrink-0 pt-px text-[10.5px] font-medium ${
+                            inUse ? "text-primary/70" : "text-primary"
+                          }`}
+                        >
+                          {inUse ? "in use" : "use"}
+                        </span>
+                      </button>
+                    );
+                  })}
+                  <div className="pl-3 pr-2.5 pt-1.5 pb-2 text-[11px] text-base-content/50">
+                    Replaces the box above. You can edit it afterwards.
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {loading && recent.length === 0 && (
+            <span className="text-[11px] text-base-content/40">
+              Looking for messages on this topic…
+            </span>
+          )}
+
+          {/* The payload itself, sent verbatim. A contenteditable rather than
+              a textarea, so the token can be a chip that says what it is: the
+              chip is atomic, so it cannot be half-deleted or typed inside, and
+              everything around it is ordinary text editing. */}
+          <div
+            ref={editorRef}
+            className={editorClass}
+            contentEditable
+            suppressContentEditableWarning
+            role="textbox"
+            aria-multiline="true"
+            aria-label={reading ? "Message shape" : "Payload"}
+            spellCheck={false}
+            onInput={handleInput}
+            onPaste={(e) => {
+              // Paste plain text: clipboard HTML would drag styling, and worse,
+              // markup that reads back as payload it never contained.
+              e.preventDefault();
+              const text = e.clipboardData.getData("text/plain");
+              document.execCommand("insertText", false, text);
+            }}
+          />
+
+          {/* Put the token where it belongs: anywhere the user points, or onto
+              a value the editor recognised */}
+          {(literals.length > 0 || tokenPresent || acceptsToken) && (
+            <div className="flex flex-col gap-1.5">
+              <span className="text-[11px] text-base-content/60">
+                {!acceptsToken
+                  ? `This panel publishes a fixed message — remove ${TOKEN_LABEL} to send it.`
+                  : tokenPresent
+                    ? `Put the caret where ${TOKEN_LABEL} should go instead, or select text to replace, then move it.`
+                    : reading
+                      ? `Put ${TOKEN_LABEL} where the value sits — select text to replace it, or tap one of the values below.`
+                      : `Put ${TOKEN_LABEL} where the panel's value goes — select text to replace it, or tap one of the values below.`}
+              </span>
+              <div className="flex flex-wrap gap-1.5">
+                {acceptsToken && (
+                  <button
+                    type="button"
+                    // mousedown, not click: the default would move focus out of
+                    // the editor and take the selection being aimed at with it
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      dropToken();
+                    }}
+                    className="inline-flex items-center gap-1 h-6 px-2.5 rounded-full border border-dashed border-primary/60 text-primary font-mono text-[11px] cursor-pointer hover:bg-primary/10"
+                  >
+                    <span aria-hidden="true">{tokenPresent ? "↦" : "+"}</span>
+                    {tokenPresent ? `move ${TOKEN_LABEL}` : TOKEN_LABEL}
+                  </button>
+                )}
+                {tokenPresent && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onTemplateChange(clearToken(template, restore));
+                      setPrevious(null);
+                    }}
+                    className="inline-flex items-center gap-1.5 h-6 px-2.5 rounded-full border border-primary bg-primary/15 text-primary font-mono text-[11px] cursor-pointer"
+                  >
+                    {TOKEN_LABEL} ✕
+                  </button>
+                )}
+                {literals.map((literal, index) => (
+                  <button
+                    key={`${literal.start}-${literal.text}`}
+                    type="button"
+                    onClick={() => handleMark(index)}
+                    className="inline-flex items-center h-6 px-2.5 rounded-full border border-base-300 bg-base-200/40 font-mono text-[11px] cursor-pointer hover:border-primary"
+                  >
+                    {literal.text}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Exactly what goes on the wire, in a section of its own so it is
+              not mistaken for another thing to fill in. The panel's own control
+              lives here too, so working it and reading the bytes it produces is
+              one place rather than a demo above and its result below. */}
+          <div className="rounded-lg border border-base-300 bg-base-200/40 p-2.5 flex flex-col gap-2 min-w-0">
+            <div className="flex items-center gap-1.5">
+              <PreviewIcon className="text-base-content/50 text-xs shrink-0" />
+              <span className="text-[11px] font-medium text-base-content/70">
+                Preview
+              </span>
+            </div>
+
+            <p className="text-[11px] text-base-content/60 leading-normal">
+              {previewNote ?? defaultNote}
+            </p>
+
+            {children}
+
+            {reading && latest && (
+              <div className="flex items-start gap-2 min-w-0">
+                <span className="text-[11px] text-base-content/60 w-14 shrink-0 pt-0.5">
+                  Latest
+                </span>
+                <span className="font-mono text-xs break-all min-w-0">
+                  {String(readValue(template, latest).value)}
+                </span>
+              </div>
+            )}
+
+            {!reading &&
+              rendered.map((preview) => (
+                <div
+                  key={preview.key}
+                  className="flex items-start gap-2 min-w-0"
+                >
+                  {/* One-state panels label the line from the control above it;
+                      a blank key means the control has already said it. */}
+                  {preview.key && (
+                    <span className="text-[11px] text-base-content/60 w-14 shrink-0 pt-0.5">
+                      {preview.key}
+                    </span>
+                  )}
+                  <span className="font-mono text-xs break-all min-w-0">
+                    {preview.bytes}
+                  </span>
+                </div>
+              ))}
+          </div>
+        </div>
+      )}
+    </fieldset>
+  );
+}

--- a/frontend/src/components/panels/ReadBackSection.tsx
+++ b/frontend/src/components/panels/ReadBackSection.tsx
@@ -1,0 +1,93 @@
+import { RiSwap2Line } from "react-icons/ri";
+import type { BrokerStatus } from "../../hooks/useBrokers";
+import BrokerTopicSection from "./BrokerTopicSection";
+import PayloadBuilder from "./PayloadBuilder";
+
+interface Props {
+  enabled: boolean;
+  onEnabledChange: (enabled: boolean) => void;
+  brokerStatuses: BrokerStatus[];
+  brokerId: string;
+  onBrokerChange: (brokerId: string) => void;
+  topic: string;
+  onTopicChange: (topic: string) => void;
+  onPickTopic?: () => void;
+  readTemplate: string;
+  onReadTemplateChange: (template: string) => void;
+  /** "state" for the toggle, "value" for the slider. */
+  noun?: string;
+}
+
+/**
+ * Where the panel reads back from, when that is not simply the topic it
+ * publishes to in the shape it publishes.
+ *
+ * Off by default and collapsed to a single switch: the common case is a device
+ * that reports on its own command topic, which needs no configuration at all.
+ * Switching it on reveals a full broker/topic pair and a payload editor in read
+ * mode, so an entirely different shape on an entirely different broker can be
+ * described the same way the outgoing payload is.
+ */
+export default function ReadBackSection({
+  enabled,
+  onEnabledChange,
+  brokerStatuses,
+  brokerId,
+  onBrokerChange,
+  topic,
+  onTopicChange,
+  onPickTopic,
+  readTemplate,
+  onReadTemplateChange,
+  noun = "value",
+}: Props) {
+  return (
+    <div className="border border-base-300 bg-base-200/40 rounded-xl p-3.5 flex flex-col gap-3 transition-all">
+      <label className="flex items-center justify-between w-full cursor-pointer group select-none">
+        <div className="flex items-center gap-1.5 font-medium text-xs text-base-content/80 group-hover:text-base-content transition-colors">
+          <RiSwap2Line className="text-accent text-sm shrink-0" />
+          <span>Reads {noun} from a different topic</span>
+        </div>
+        <input
+          type="checkbox"
+          className="toggle toggle-xs toggle-primary"
+          checked={enabled}
+          onChange={(e) => onEnabledChange(e.target.checked)}
+        />
+      </label>
+
+      {!enabled && (
+        <p className="text-[11px] text-base-content/60 leading-normal">
+          The device reports on the command topic, in the same shape the panel
+          publishes.
+        </p>
+      )}
+
+      {enabled && (
+        <div className="flex flex-col gap-3 pt-1 border-t border-base-300/60">
+          <BrokerTopicSection
+            selectedBrokerId={brokerId}
+            onBrokerChange={onBrokerChange}
+            brokerStatuses={brokerStatuses}
+            topic={topic}
+            onTopicChange={onTopicChange}
+            onPickTopic={onPickTopic}
+            topicLabel="State topic"
+            allowWildcards={true}
+            allowMultiple={false}
+            helpText={`Where the device reports its actual ${noun}. Read-only, so wildcards are allowed.`}
+          />
+
+          <PayloadBuilder
+            mode="read"
+            template={readTemplate}
+            onTemplateChange={onReadTemplateChange}
+            previews={[]}
+            brokerId={brokerId}
+            topic={topic}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/panels/SliderPanel.test.tsx
+++ b/frontend/src/components/panels/SliderPanel.test.tsx
@@ -77,6 +77,18 @@ describe("SliderPanel publishing", () => {
     );
   });
 
+  it("publishes nothing when the readout is cleared and confirmed", () => {
+    render(<SliderPanel panelId="p1" brokerId="b1" config={config} />);
+
+    fireEvent.doubleClick(screen.getByTitle(/Double-click/));
+    const field = screen.getByLabelText("Value") as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "" } });
+    fireEvent.keyDown(field, { key: "Enter" });
+
+    // Number("") is 0, which would have sent the range minimum
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
   it("escape abandons what was typed", () => {
     render(<SliderPanel panelId="p1" brokerId="b1" config={config} />);
 

--- a/frontend/src/components/panels/SliderPanel.test.tsx
+++ b/frontend/src/components/panels/SliderPanel.test.tsx
@@ -1,0 +1,104 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import SliderPanel from "./SliderPanel";
+
+const postMock = vi.fn();
+const getExplorerHistoryMock = vi.fn();
+
+vi.mock("../../hooks/useWebSocket", () => ({
+  useWebSocket: () => ({ subscribe: vi.fn() }),
+}));
+
+vi.mock("../../api/client", () => ({
+  api: {
+    post: (...args: unknown[]) => postMock(...args),
+    getExplorerHistory: (...args: unknown[]) => getExplorerHistoryMock(...args),
+  },
+}));
+
+const config = { topic: "home/lamp/brightness", min: 0, max: 100, step: 1 };
+
+function renderSlider() {
+  render(<SliderPanel panelId="p1" brokerId="b1" config={config} />);
+  return screen.getByRole("slider") as HTMLInputElement;
+}
+
+describe("SliderPanel publishing", () => {
+  beforeEach(() => {
+    postMock.mockReset().mockResolvedValue({});
+    getExplorerHistoryMock.mockReset().mockResolvedValue([]);
+  });
+
+  afterEach(cleanup);
+
+  it("does not publish on a keyup that never moved the handle", () => {
+    const slider = renderSlider();
+    // Tabbing onto the slider releases the key over it, with no value change
+    fireEvent.keyUp(slider, { key: "Tab" });
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("publishes once the handle has actually moved", () => {
+    const slider = renderSlider();
+    fireEvent.change(slider, { target: { value: "40" } });
+    fireEvent.keyUp(slider, { key: "ArrowRight" });
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(postMock).toHaveBeenCalledWith(
+      "/api/publish",
+      expect.objectContaining({ topic: "home/lamp/brightness", payload: "40" }),
+    );
+  });
+
+  it("publishes a value typed into the readout", () => {
+    render(<SliderPanel panelId="p1" brokerId="b1" config={config} />);
+
+    fireEvent.doubleClick(screen.getByTitle(/Double-click/));
+    const field = screen.getByLabelText("Value") as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "72" } });
+    fireEvent.keyDown(field, { key: "Enter" });
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/api/publish",
+      expect.objectContaining({ payload: "72" }),
+    );
+  });
+
+  it("snaps a typed value onto the range", () => {
+    render(<SliderPanel panelId="p1" brokerId="b1" config={config} />);
+
+    fireEvent.doubleClick(screen.getByTitle(/Double-click/));
+    const field = screen.getByLabelText("Value") as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "500" } });
+    fireEvent.keyDown(field, { key: "Enter" });
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/api/publish",
+      expect.objectContaining({ payload: "100" }),
+    );
+  });
+
+  it("escape abandons what was typed", () => {
+    render(<SliderPanel panelId="p1" brokerId="b1" config={config} />);
+
+    fireEvent.doubleClick(screen.getByTitle(/Double-click/));
+    const field = screen.getByLabelText("Value") as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "72" } });
+    fireEvent.keyDown(field, { key: "Escape" });
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText("Value")).toBeNull();
+  });
+
+  it("offers no typing on a panel with no topic to publish to", () => {
+    render(<SliderPanel panelId="p1" brokerId="b1" config={{}} />);
+    expect(screen.queryByTitle(/Double-click/)).toBeNull();
+  });
+
+  it("does not publish again on the blur that follows a committed move", () => {
+    const slider = renderSlider();
+    fireEvent.change(slider, { target: { value: "40" } });
+    fireEvent.keyUp(slider, { key: "ArrowRight" });
+    fireEvent.blur(slider);
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/panels/SliderPanel.tsx
+++ b/frontend/src/components/panels/SliderPanel.tsx
@@ -571,8 +571,12 @@ function SliderRuntime({ panelId, brokerId, config }: SliderPanelProps) {
 
   /** Publish what was typed into the readout, snapped onto the range. */
   const commitTyped = () => {
-    const raw = Number(typed);
+    const text = (typed ?? "").trim();
     setTyped(null);
+    // `Number("")` is 0, so a field cleared and confirmed would publish the
+    // range minimum — a command nobody asked for. Nothing typed, nothing sent.
+    if (text === "") return;
+    const raw = Number(text);
     if (!Number.isFinite(raw)) return;
     commit(raw);
   };

--- a/frontend/src/components/panels/SliderPanel.tsx
+++ b/frontend/src/components/panels/SliderPanel.tsx
@@ -1,0 +1,752 @@
+import { useState, useEffect, useRef } from "react";
+import { MdTune } from "react-icons/md";
+import { RiErrorWarningLine, RiLoader4Line, RiTimeLine } from "react-icons/ri";
+import { useWebSocket } from "../../hooks/useWebSocket";
+import { usePanelSize } from "../../hooks/usePanelSize";
+import { api } from "../../api/client";
+import type { BrokerStatus } from "../../hooks/useBrokers";
+import BrokerTopicSection from "./BrokerTopicSection";
+import MqttOptionsSection from "./MqttOptionsSection";
+import PanelModalFrame from "./PanelModalFrame";
+import PayloadBuilder from "./PayloadBuilder";
+import ReadBackSection from "./ReadBackSection";
+import {
+  VALUE_TOKEN,
+  effectiveReadPath,
+  effectiveReadTemplate,
+  payloadIssue,
+  renderPayload,
+} from "./payloadShape";
+import {
+  clampToRange,
+  normalizeRange,
+  parseSliderValue,
+  valueToFraction,
+  DEFAULT_MAX,
+  DEFAULT_MIN,
+  DEFAULT_STEP,
+} from "./sliderUtils";
+
+/** How long to wait for the state topic to confirm a write before giving up. */
+const CONFIRM_TIMEOUT_MS = 5000;
+
+export interface SliderConfig {
+  /** Command topic — the slider publishes here. */
+  topic?: string;
+  /** Reads back from its own broker/topic/shape rather than the command one. */
+  separateRead?: boolean;
+  /** State/telemetry topic, used when separateRead is set. */
+  stateTopic?: string;
+  /** Broker the state topic lives on; defaults to the command broker. */
+  stateBrokerId?: string;
+  /** Shape of incoming messages, with `◆` marking the value to read. */
+  readTemplate?: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  /** Shown next to the value readout, e.g. "%" or "°C". */
+  unit?: string;
+  /** Legacy read path, still honoured when no template marks the value. */
+  valueKey?: string;
+  /**
+   * Which field sent the user to the topic picker. The picker round-trips the
+   * draft config and hands the chosen topic back as `initialTopic`, which would
+   * otherwise always land in the command topic — this says where it belongs.
+   */
+  pickTarget?: "topic" | "stateTopic";
+  /** Command broker carried across the picker round-trip. */
+  commandBrokerId?: string;
+  /**
+   * The literal payload published, with `◆` marking where the position drops
+   * in. Absent means the position is published on its own.
+   */
+  payloadTemplate?: string;
+  qos?: number;
+  retain?: boolean;
+}
+
+interface ModalProps {
+  config: SliderConfig;
+  brokerId: string;
+  brokerStatuses: BrokerStatus[];
+  onSave: (cfg: SliderConfig, brokerId: string) => void;
+  onClose: () => void;
+  onPickTopic?: (data: {
+    currentTopic: string;
+    selectedBrokerId: string;
+    draftConfig?: SliderConfig;
+  }) => void;
+  initialTopic?: string;
+  initialBrokerId?: string;
+}
+
+export function SliderConfigModal({
+  config,
+  brokerId,
+  brokerStatuses,
+  onSave,
+  onClose,
+  onPickTopic,
+  initialTopic,
+  initialBrokerId,
+}: ModalProps) {
+  const defaultBrokerId =
+    brokerStatuses.find((b) => b.is_enabled)?.id ?? brokerStatuses[0]?.id ?? "";
+  // A topic picked for the state field must not overwrite the command topic
+  const pickedForState = config.pickTarget === "stateTopic";
+  const [topic, setTopic] = useState(
+    (pickedForState ? config.topic : initialTopic) ?? config.topic ?? "",
+  );
+  const [separateRead, setSeparateRead] = useState(
+    config.separateRead ?? Boolean(config.stateTopic?.trim()),
+  );
+  const [stateTopic, setStateTopic] = useState(
+    (pickedForState ? initialTopic : config.stateTopic) ??
+      config.stateTopic ??
+      "",
+  );
+  const [stateBrokerId, setStateBrokerId] = useState(
+    (pickedForState ? initialBrokerId : config.stateBrokerId) ??
+      config.stateBrokerId ??
+      "",
+  );
+  const [readTemplate, setReadTemplate] = useState(
+    config.readTemplate ?? config.payloadTemplate ?? VALUE_TOKEN,
+  );
+  const [min, setMin] = useState(String(config.min ?? DEFAULT_MIN));
+  const [max, setMax] = useState(String(config.max ?? DEFAULT_MAX));
+  const [step, setStep] = useState(String(config.step ?? DEFAULT_STEP));
+  const [unit, setUnit] = useState(config.unit ?? "");
+  const [payloadTemplate, setPayloadTemplate] = useState(
+    config.payloadTemplate ?? VALUE_TOKEN,
+  );
+  // Lets the user sweep the range and watch the bytes change
+  const [demoPosition, setDemoPosition] = useState<number | null>(null);
+  const [qos, setQos] = useState(config.qos ?? 0);
+  const [retain, setRetain] = useState(config.retain ?? false);
+  const [selectedBrokerId, setSelectedBrokerId] = useState(
+    (pickedForState ? config.commandBrokerId : initialBrokerId) ||
+      brokerId ||
+      defaultBrokerId,
+  );
+
+  // Everything the user has typed so far, carried through the picker so a trip
+  // to the explorer does not discard in-progress edits.
+  const draft = (pickTarget: "topic" | "stateTopic"): SliderConfig => ({
+    topic,
+    separateRead,
+    stateTopic,
+    stateBrokerId,
+    readTemplate,
+    min: Number(min),
+    max: Number(max),
+    step: Number(step),
+    unit,
+    payloadTemplate,
+    valueKey: config.valueKey,
+    qos,
+    retain,
+    pickTarget,
+    commandBrokerId: selectedBrokerId,
+  });
+
+  const hasWildcardWarning = topic.includes("+") || topic.includes("#");
+  const effectiveStateTopic = separateRead ? stateTopic.trim() : "";
+  const effectiveStateBroker =
+    (separateRead && stateBrokerId) || selectedBrokerId;
+
+  // `Number("")` is 0, which would let a cleared Low save as a silent zero, so
+  // a blank field parses as NaN and fails the checks below like any other
+  // unusable entry.
+  const parseField = (raw: string) => (raw.trim() === "" ? NaN : Number(raw));
+
+  const minNum = parseField(min);
+  const maxNum = parseField(max);
+  const stepNum = parseField(step);
+  const rangeBlank = !Number.isFinite(minNum) || !Number.isFinite(maxNum);
+  const rangeInvalid = rangeBlank || maxNum <= minNum;
+  const stepInvalid = !Number.isFinite(stepNum) || stepNum <= 0;
+
+  // Show the user what actually goes on the wire, using the midpoint so the
+  // example is representative rather than always the minimum.
+  const exampleValue = rangeInvalid
+    ? DEFAULT_MAX / 2
+    : clampToRange(
+        (minNum + maxNum) / 2,
+        normalizeRange({ min: minNum, max: maxNum, step: stepNum }),
+      );
+
+  const previewPosition = demoPosition ?? exampleValue;
+
+  // A payload with nowhere for the position to go publishes the same bytes on
+  // every move, so it blocks Save the way a missing topic does.
+  const payloadProblem =
+    payloadIssue({ template: payloadTemplate }) ??
+    (separateRead
+      ? payloadIssue({ template: readTemplate, mode: "read" })
+      : null);
+
+  return (
+    <PanelModalFrame
+      title="Slider Configuration"
+      icon={MdTune}
+      onClose={onClose}
+      onSave={() =>
+        onSave(
+          {
+            topic,
+            separateRead,
+            stateTopic: effectiveStateTopic,
+            stateBrokerId: separateRead ? effectiveStateBroker : undefined,
+            readTemplate: separateRead ? readTemplate : undefined,
+            min: minNum,
+            max: maxNum,
+            step: stepNum,
+            unit: unit.trim(),
+            valueKey: config.valueKey,
+            payloadTemplate,
+            qos,
+            retain,
+          },
+          selectedBrokerId || defaultBrokerId,
+        )
+      }
+      saveDisabled={
+        brokerStatuses.length === 0 ||
+        !topic.trim() ||
+        hasWildcardWarning ||
+        rangeInvalid ||
+        stepInvalid ||
+        Boolean(payloadProblem)
+      }
+      maxWidthClass="max-w-lg"
+    >
+      <BrokerTopicSection
+        selectedBrokerId={selectedBrokerId}
+        onBrokerChange={setSelectedBrokerId}
+        brokerStatuses={brokerStatuses}
+        topic={topic}
+        onTopicChange={setTopic}
+        onPickTopic={
+          onPickTopic
+            ? () =>
+                onPickTopic({
+                  currentTopic: topic,
+                  selectedBrokerId,
+                  draftConfig: draft("topic"),
+                })
+            : undefined
+        }
+        topicLabel="Command topic"
+        allowWildcards={false}
+        allowMultiple={false}
+        helpText="The topic the slider publishes to. Also used to read the value back unless a separate state topic is set below."
+      />
+
+      <fieldset className="fieldset p-0 border-0">
+        <legend className="fieldset-legend font-medium text-xs text-base-content/80 mb-1">
+          Range
+        </legend>
+        <div className="grid grid-cols-3 gap-2">
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] text-base-content/60">Low</span>
+            <input
+              type="number"
+              className={`input input-bordered input-sm w-full font-mono text-xs ${
+                rangeInvalid ? "input-warning" : ""
+              }`}
+              value={min}
+              onChange={(e) => setMin(e.target.value)}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] text-base-content/60">High</span>
+            <input
+              type="number"
+              className={`input input-bordered input-sm w-full font-mono text-xs ${
+                rangeInvalid ? "input-warning" : ""
+              }`}
+              value={max}
+              onChange={(e) => setMax(e.target.value)}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] text-base-content/60">Step</span>
+            <input
+              type="number"
+              min="0"
+              className={`input input-bordered input-sm w-full font-mono text-xs ${
+                stepInvalid ? "input-warning" : ""
+              }`}
+              value={step}
+              onChange={(e) => setStep(e.target.value)}
+            />
+          </label>
+        </div>
+        {rangeInvalid && (
+          <p className="text-[11px] text-warning mt-1.5 leading-normal">
+            {rangeBlank
+              ? "Low and High are both required."
+              : "High must be greater than Low."}
+          </p>
+        )}
+        {!rangeInvalid && stepInvalid && (
+          <p className="text-[11px] text-warning mt-1.5 leading-normal">
+            Step must be greater than 0.
+          </p>
+        )}
+      </fieldset>
+
+      <fieldset className="fieldset p-0 border-0">
+        <legend className="fieldset-legend font-medium text-xs text-base-content/80 mb-1">
+          Unit <span className="opacity-60 font-normal">(optional)</span>
+        </legend>
+        <input
+          className="input input-bordered input-sm w-full font-mono text-xs"
+          value={unit}
+          onChange={(e) => setUnit(e.target.value)}
+          placeholder="e.g. %"
+        />
+        <p className="text-[11px] text-base-content/60 mt-1.5 leading-normal">
+          Shown next to the value. Display only — never sent to the broker.
+        </p>
+      </fieldset>
+
+      <PayloadBuilder
+        template={payloadTemplate}
+        onTemplateChange={setPayloadTemplate}
+        previews={[{ key: "", value: String(previewPosition) }]}
+        brokerId={selectedBrokerId}
+        topic={topic}
+        previewNote="Move the handle: this is what the slider publishes at that position."
+      >
+        {/* Sweep the range and watch the bytes underneath follow. The position
+            is not repeated as a number — the payload line below is the value. */}
+        <input
+          type="range"
+          aria-label="Preview position"
+          className="range range-primary range-xs w-full"
+          min={rangeInvalid ? 0 : minNum}
+          max={rangeInvalid ? 100 : maxNum}
+          step={stepInvalid ? 1 : stepNum}
+          value={previewPosition}
+          onChange={(e) => setDemoPosition(Number(e.target.value))}
+        />
+      </PayloadBuilder>
+
+      <ReadBackSection
+        enabled={separateRead}
+        onEnabledChange={setSeparateRead}
+        brokerStatuses={brokerStatuses}
+        brokerId={effectiveStateBroker}
+        onBrokerChange={setStateBrokerId}
+        topic={stateTopic}
+        onTopicChange={setStateTopic}
+        onPickTopic={
+          onPickTopic
+            ? () =>
+                onPickTopic({
+                  currentTopic: stateTopic,
+                  selectedBrokerId: effectiveStateBroker,
+                  draftConfig: draft("stateTopic"),
+                })
+            : undefined
+        }
+        readTemplate={readTemplate}
+        onReadTemplateChange={setReadTemplate}
+        noun="value"
+      />
+
+      <MqttOptionsSection
+        qos={qos}
+        retain={retain}
+        onQosChange={setQos}
+        onRetainChange={setRetain}
+      />
+    </PanelModalFrame>
+  );
+}
+
+interface SliderPanelProps {
+  panelId: string;
+  brokerId: string;
+  config: SliderConfig;
+}
+
+/** Same HH:MM:SS footer format the gauge and toggle panels use. */
+function formatTime(ms: number): string {
+  try {
+    const d = new Date(ms);
+    const pad2 = (n: number) => String(n).padStart(2, "0");
+    return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Remounts the runtime whenever the panel is pointed at a different broker,
+ * topic or range, so stale state is dropped without a reset effect.
+ */
+export default function SliderPanel(props: SliderPanelProps) {
+  const { brokerId, config } = props;
+  const identity = [
+    brokerId,
+    config.topic ?? "",
+    config.stateTopic ?? "",
+    config.stateBrokerId ?? "",
+    config.readTemplate ?? "",
+    // The write template is also the read stencil when there is no separate
+    // state topic, so editing it has to remount the runtime.
+    config.payloadTemplate ?? "",
+    String(config.min ?? DEFAULT_MIN),
+    String(config.max ?? DEFAULT_MAX),
+    String(config.step ?? DEFAULT_STEP),
+    config.valueKey ?? "",
+  ].join("\u0000");
+
+  return <SliderRuntime key={identity} {...props} />;
+}
+
+function SliderRuntime({ panelId, brokerId, config }: SliderPanelProps) {
+  // Last value the device reported; null until the state topic says something.
+  const [remote, setRemote] = useState<number | null>(null);
+  // Handle position while the user is holding it, null when they are not.
+  const [dragging, setDragging] = useState<number | null>(null);
+  const [pending, setPending] = useState<number | null>(null);
+  const [updatedAt, setUpdatedAt] = useState<number | null>(null);
+  const [unconfirmed, setUnconfirmed] = useState(false);
+  const [error, setError] = useState(false);
+  // Set while the readout is being typed into, holding the text as typed
+  const [typed, setTyped] = useState<string | null>(null);
+
+  const { ref: sizeRef, size } = usePanelSize<HTMLDivElement>();
+  const pendingRef = useRef<number | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const commandTopic = (config.topic ?? "").split(",")[0]?.trim() ?? "";
+  const separateRead =
+    config.separateRead ?? Boolean(config.stateTopic?.trim());
+  const stateTopic =
+    (separateRead && config.stateTopic?.trim()) || commandTopic;
+  // The state topic may live on another broker entirely
+  const stateBrokerId =
+    (separateRead && config.stateBrokerId?.trim()) || brokerId;
+  const range = normalizeRange(config);
+  const unit = config.unit?.trim() ?? "";
+  const readTemplate = effectiveReadTemplate(config);
+  const valueKey = effectiveReadPath(config);
+  const qos = config.qos ?? 0;
+  const retain = config.retain ?? false;
+  const hasWildcard = commandTopic.includes("+") || commandTopic.includes("#");
+
+  const clearPendingTimer = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  };
+
+  // A message from the state topic is the source of truth: it resolves any
+  // pending write and replaces the optimistic position.
+  const applyIncomingValue = (payload: string, receivedAt: number) => {
+    const next = parseSliderValue(payload, {
+      template: readTemplate,
+      path: valueKey,
+    });
+    if (next === null) return;
+
+    setRemote(next);
+    setUpdatedAt(receivedAt);
+
+    const inFlight = pendingRef.current;
+    if (inFlight !== null) {
+      clearPendingTimer();
+      pendingRef.current = null;
+      setPending(null);
+      // Devices commonly round or clamp what they were sent, so anything
+      // within a step of the request counts as having landed.
+      setUnconfirmed(Math.abs(next - inFlight) > range.step);
+    }
+  };
+
+  useEffect(() => clearPendingTimer, []);
+
+  // Seed the last known value from history so a reload isn't blank
+  useEffect(() => {
+    if (!stateBrokerId || !stateTopic) return;
+
+    let cancelled = false;
+    api
+      .getExplorerHistory(stateBrokerId, stateTopic)
+      .then((records) => {
+        if (cancelled || !records || records.length === 0) return;
+        const sorted = [...records].sort(
+          (a, b) =>
+            new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+        );
+        const last = sorted[0];
+        const parsed = new Date(last.timestamp).getTime();
+        applyIncomingValue(
+          last.payload,
+          Number.isNaN(parsed) ? Date.now() : parsed,
+        );
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stateBrokerId, stateTopic, valueKey]);
+
+  // Live updates
+  const { subscribe } = useWebSocket({
+    onMessage: (msgStr) => {
+      try {
+        const msg = JSON.parse(msgStr) as {
+          topic: string;
+          payload: string;
+          timestamp?: string;
+        };
+        const parsed = msg.timestamp
+          ? new Date(msg.timestamp).getTime()
+          : Date.now();
+        applyIncomingValue(
+          msg.payload,
+          Number.isNaN(parsed) ? Date.now() : parsed,
+        );
+      } catch {
+        // Ignore invalid message JSON frame
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (!stateTopic) return;
+    subscribe({
+      panel_id: panelId,
+      broker_id: stateBrokerId,
+      topics: [stateTopic],
+    });
+  }, [panelId, stateBrokerId, stateTopic, subscribe]);
+
+  const disabled = !commandTopic || hasWildcard;
+
+  // Publishes once, when the handle is released — dragging only moves the
+  // local position, so one adjustment is one MQTT message.
+  const commit = async (raw: number) => {
+    setDragging(null);
+    if (disabled) return;
+
+    const value = clampToRange(raw, range);
+    setUnconfirmed(false);
+    setError(false);
+    pendingRef.current = value;
+    setPending(value);
+
+    clearPendingTimer();
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null;
+      pendingRef.current = null;
+      setPending(null);
+      setUnconfirmed(true);
+    }, CONFIRM_TIMEOUT_MS);
+
+    try {
+      await api.post("/api/publish", {
+        broker_id: brokerId,
+        topic: commandTopic,
+        payload: renderPayload(config.payloadTemplate ?? VALUE_TOKEN, value),
+        qos,
+        retain,
+      });
+    } catch {
+      clearPendingTimer();
+      pendingRef.current = null;
+      setPending(null);
+      setError(true);
+    }
+  };
+
+  /** Publish what was typed into the readout, snapped onto the range. */
+  const commitTyped = () => {
+    const raw = Number(typed);
+    setTyped(null);
+    if (!Number.isFinite(raw)) return;
+    commit(raw);
+  };
+
+  // Follow the finger first, then the optimistic write, then the device.
+  const displayed = dragging ?? pending ?? remote;
+  const handlePosition = displayed ?? range.min;
+
+  // Scale the readout with the panel, like GaugePanel does.
+  const availH = Math.max(40, (size.height || 200) - 34);
+  const availW = Math.max(40, (size.width || 240) - 16);
+  const valueFontSize = Math.round(
+    Math.max(13, Math.min(availH * 0.26, availW * 0.17, 48)),
+  );
+  const unitFontSize = Math.max(9, Math.round(valueFontSize * 0.4));
+  // The handle is what the user actually has to hit, so it grows with the panel
+  // like the readout does — never below a comfortable touch target.
+  const thumbSize = Math.round(
+    Math.max(24, Math.min(availW * 0.11, availH * 0.3, 44)),
+  );
+  // daisyUI draws the track at half the thumb, which reads as a bar with a knob
+  // on it. A hairline under a round handle makes the grabbable part obvious:
+  // the circle stays several times wider than the line it rides on.
+  const trackSize = Math.min(10, Math.max(6, Math.round(thumbSize * 0.22)));
+  const filled = valueToFraction(handlePosition, range);
+
+  let status: React.ReactNode = null;
+  if (!commandTopic) {
+    status = <span className="text-base-content/50">No topic configured</span>;
+  } else if (hasWildcard) {
+    status = (
+      <span className="text-warning inline-flex items-center gap-1">
+        <RiErrorWarningLine className="shrink-0" />
+        Wildcard topic
+      </span>
+    );
+  } else if (pending !== null) {
+    status = (
+      <span className="text-base-content/60 inline-flex items-center gap-1">
+        <RiLoader4Line className="animate-spin shrink-0" />
+        confirming…
+      </span>
+    );
+  } else if (error) {
+    status = (
+      <span className="text-error inline-flex items-center gap-1">
+        <RiErrorWarningLine className="shrink-0" />
+        publish failed
+      </span>
+    );
+  } else if (unconfirmed) {
+    status = (
+      <span className="text-warning inline-flex items-center gap-1">
+        <RiErrorWarningLine className="shrink-0" />
+        not confirmed
+      </span>
+    );
+  } else if (updatedAt === null) {
+    status = <span className="text-base-content/50">waiting for value…</span>;
+  }
+
+  return (
+    <div
+      ref={sizeRef}
+      className="flex flex-col h-full justify-between p-2 overflow-hidden"
+    >
+      <div className="grid flex-1 min-h-0 w-full grid-rows-[1fr_auto_1fr] items-center">
+        <div className="flex items-baseline justify-center gap-1 leading-none self-end pb-2">
+          {typed !== null ? (
+            <input
+              type="number"
+              autoFocus
+              className="font-bold font-mono text-base-content tabular-nums bg-transparent border-b border-primary outline-none text-center w-[5ch] p-0 leading-none"
+              style={{ fontSize: valueFontSize }}
+              min={range.min}
+              max={range.max}
+              step={range.step}
+              value={typed}
+              aria-label="Value"
+              onChange={(e) => setTyped(e.target.value)}
+              onBlur={commitTyped}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitTyped();
+                if (e.key === "Escape") setTyped(null);
+              }}
+            />
+          ) : (
+            <span
+              className={`font-bold font-mono text-base-content tabular-nums ${
+                disabled ? "" : "cursor-text"
+              }`}
+              style={{ fontSize: valueFontSize }}
+              title={disabled ? undefined : "Double-click to type a value"}
+              onDoubleClick={() => {
+                if (disabled) return;
+                setTyped(String(displayed ?? range.min));
+              }}
+            >
+              {displayed === null ? "—" : displayed}
+            </span>
+          )}
+          {unit && (
+            <span
+              className="font-mono text-base-content/60"
+              style={{ fontSize: unitFontSize }}
+            >
+              {unit}
+            </span>
+          )}
+        </div>
+
+        <div className="w-full">
+          <input
+            type="range"
+            className={`range range-primary range-hairline w-full ${
+              pending !== null ? "animate-pulse" : ""
+            }`}
+            style={
+              {
+                "--range-thumb-size": `${thumbSize}px`,
+                "--track-size": `${trackSize}px`,
+                // Off: daisyUI's fill is a shadow cast by the thumb, as tall as
+                // the thumb. The track's own gradient replaces it.
+                "--range-fill": "0",
+                "--range-progress-x": `${filled * 100}%`,
+              } as React.CSSProperties
+            }
+            min={range.min}
+            max={range.max}
+            step={range.step}
+            value={handlePosition}
+            disabled={disabled}
+            aria-label={commandTopic || "Slider"}
+            title={
+              hasWildcard
+                ? "Cannot publish to wildcard topics (+ or #)"
+                : !commandTopic
+                  ? "No topic configured"
+                  : undefined
+            }
+            onChange={(e) => setDragging(Number(e.target.value))}
+            onPointerUp={(e) => commit(Number(e.currentTarget.value))}
+            onKeyUp={(e) => {
+              // keyup fires on whichever element has focus, so the Tab that moves
+              // focus onto the slider lands here too. Only a key that actually
+              // moved the handle leaves a drag to commit.
+              if (dragging !== null) commit(Number(e.currentTarget.value));
+            }}
+            onBlur={(e) => {
+              // Pointer released outside the track still ends the drag.
+              if (dragging !== null) commit(Number(e.currentTarget.value));
+            }}
+          />
+        </div>
+
+        {/* Same width as the track above, so the ends line up with it */}
+        <div className="flex justify-between w-full text-[10px] text-base-content/40 font-mono self-start pt-1">
+          <span>{range.min}</span>
+          <span>{range.max}</span>
+        </div>
+      </div>
+
+      {/* Footer Meta */}
+      <div className="flex items-center justify-between gap-2 text-[10px] text-base-content/50 pt-1.5 border-t border-base-200 shrink-0">
+        <div className="flex items-center gap-1 min-w-0">
+          {updatedAt !== null && (
+            <>
+              <RiTimeLine className="text-xs shrink-0" />
+              <span className="truncate">{formatTime(updatedAt)}</span>
+            </>
+          )}
+        </div>
+        {status && <div className="truncate">{status}</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/panels/definitions.tsx
+++ b/frontend/src/components/panels/definitions.tsx
@@ -9,6 +9,7 @@ import {
   MdHorizontalRule,
   MdImage,
   MdToggleOn,
+  MdTune,
 } from "react-icons/md";
 import { api } from "../../api/client";
 import type { PanelDefinition, ValidationResult } from "./types";
@@ -34,6 +35,44 @@ import TogglePanel, {
   ToggleConfigModal,
   type ToggleConfig,
 } from "./TogglePanel";
+import SliderPanel, {
+  SliderConfigModal,
+  type SliderConfig,
+} from "./SliderPanel";
+import { normalizeRange, DEFAULT_MAX, DEFAULT_MIN } from "./sliderUtils";
+import { VALUE_TOKEN, payloadIssue } from "./payloadShape";
+
+/**
+ * The command topic of a publishing panel: it has to exist, and it cannot carry
+ * wildcards (they are legal on a state topic, which is only read).
+ */
+function commandTopicIssue(topic: string | undefined): string | null {
+  const trimmed = (topic ?? "").trim();
+  if (!trimmed) return "No topic configured";
+  if (trimmed.includes("+") || trimmed.includes("#")) {
+    return "Cannot publish to wildcard topics (+ or #)";
+  }
+  return null;
+}
+
+/** Both halves of "can this panel publish at all?", as one validation result. */
+function publishIssueResult(
+  topic: string | undefined,
+  payload: string | null,
+): ValidationResult | null {
+  const topicProblem = commandTopicIssue(topic);
+  if (topicProblem) {
+    return {
+      isValid: false,
+      warning: topicProblem,
+      errors: { topic: topicProblem },
+    };
+  }
+  if (payload) {
+    return { isValid: false, warning: payload, errors: { payload } };
+  }
+  return null;
+}
 
 export const gaugePanelDefinition: PanelDefinition<GaugeConfig> = {
   type: "gauge",
@@ -326,6 +365,76 @@ export const togglePanelDefinition: PanelDefinition<ToggleConfig> = {
   Component: TogglePanel,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConfigModal: ToggleConfigModal as any,
+};
+
+export const sliderPanelDefinition: PanelDefinition<SliderConfig> = {
+  type: "slider",
+  label: "Slider",
+  category: "control",
+  icon: MdTune,
+  description: "Set a numeric value on a device and reflect its real position",
+  resolvePickedTopic: (_existing, picked) => picked,
+  isEmpty: (config) =>
+    !config?.topic?.trim()
+      ? {
+          message: "No topic configured — open settings to add topic",
+          actionLabel: "Configure Topic",
+        }
+      : null,
+  // Same split as the toggle: wildcards are illegal on the command topic (it is
+  // published to) but fine on the state topic, which is only read.
+  validateConfig: (config): ValidationResult => {
+    const min = config?.min ?? DEFAULT_MIN;
+    const max = config?.max ?? DEFAULT_MAX;
+    const problem = publishIssueResult(
+      config?.topic,
+      payloadIssue({ template: config?.payloadTemplate ?? VALUE_TOKEN }) ??
+        (config?.separateRead
+          ? payloadIssue({
+              template: config?.readTemplate ?? VALUE_TOKEN,
+              mode: "read",
+            })
+          : null),
+    );
+    if (problem) return problem;
+    if (!(max > min)) {
+      return {
+        isValid: false,
+        warning: "High limit must be greater than Low limit",
+        errors: { range: "High limit must be greater than Low limit" },
+      };
+    }
+    return { isValid: true };
+  },
+  getHeaderMeta: (config) => {
+    const topic = (config?.topic ?? "").trim();
+    const stateTopic = config?.stateTopic?.trim();
+    if (!topic) return { topicSummary: "not configured" };
+    const range = normalizeRange(config ?? {});
+    const unit = config?.unit?.trim() ?? "";
+    return {
+      topicSummary: stateTopic ? `${topic} ⇄ ${stateTopic}` : topic,
+      topicDetail: stateTopic
+        ? `command → ${topic} · value ← ${stateTopic}`
+        : `command and value → ${topic}`,
+      payloadPreview: `${range.min}–${range.max}${unit ? ` ${unit}` : ""}`,
+    };
+  },
+  preview: (
+    <div className="flex flex-col items-center justify-center h-full gap-2 p-2">
+      <span className="text-sm font-bold font-mono text-base-content">60%</span>
+      <div className="relative w-20 h-1.5 rounded-full bg-base-content/15">
+        <div className="absolute inset-y-0 left-0 w-3/5 rounded-full bg-primary" />
+        <span className="absolute -top-1 left-3/5 -ml-2 w-4 h-4 rounded-full bg-primary shadow-md" />
+      </div>
+      <span className="text-[10px] text-base-content/50 font-mono">
+        home/lamp/brightness
+      </span>
+    </div>
+  ),
+  Component: SliderPanel,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ConfigModal: SliderConfigModal as any,
 };
 
 export const textPanelDefinition: PanelDefinition<TextConfig> = {

--- a/frontend/src/components/panels/definitions.tsx
+++ b/frontend/src/components/panels/definitions.tsx
@@ -39,8 +39,8 @@ import SliderPanel, {
   SliderConfigModal,
   type SliderConfig,
 } from "./SliderPanel";
-import { normalizeRange, DEFAULT_MAX, DEFAULT_MIN } from "./sliderUtils";
-import { VALUE_TOKEN, payloadIssue } from "./payloadShape";
+import { DEFAULT_MAX, DEFAULT_MIN } from "./sliderUtils";
+import { VALUE_TOKEN, describeTemplate, payloadIssue } from "./payloadShape";
 
 /**
  * The command topic of a publishing panel: it has to exist, and it cannot carry
@@ -410,14 +410,19 @@ export const sliderPanelDefinition: PanelDefinition<SliderConfig> = {
     const topic = (config?.topic ?? "").trim();
     const stateTopic = config?.stateTopic?.trim();
     if (!topic) return { topicSummary: "not configured" };
-    const range = normalizeRange(config ?? {});
-    const unit = config?.unit?.trim() ?? "";
+    // The payload as the config modal shows it, so the two describe the panel
+    // the same way. The range is already on the panel's own face.
+    const sends = describeTemplate(config?.payloadTemplate ?? VALUE_TOKEN);
+    const reads =
+      config?.separateRead && config?.readTemplate
+        ? describeTemplate(config.readTemplate)
+        : null;
     return {
       topicSummary: stateTopic ? `${topic} ⇄ ${stateTopic}` : topic,
       topicDetail: stateTopic
         ? `command → ${topic} · value ← ${stateTopic}`
         : `command and value → ${topic}`,
-      payloadPreview: `${range.min}–${range.max}${unit ? ` ${unit}` : ""}`,
+      payloadPreview: reads ? `sends  ${sends}\nreads  ${reads}` : sends,
     };
   },
   preview: (

--- a/frontend/src/components/panels/index.ts
+++ b/frontend/src/components/panels/index.ts
@@ -7,6 +7,7 @@ import {
   inputPanelDefinition,
   cronPanelDefinition,
   togglePanelDefinition,
+  sliderPanelDefinition,
   textPanelDefinition,
   separatorPanelDefinition,
   imagePanelDefinition,
@@ -20,6 +21,7 @@ registerPanel(buttonPanelDefinition);
 registerPanel(inputPanelDefinition);
 registerPanel(cronPanelDefinition);
 registerPanel(togglePanelDefinition);
+registerPanel(sliderPanelDefinition);
 registerPanel(textPanelDefinition);
 registerPanel(separatorPanelDefinition);
 registerPanel(imagePanelDefinition);

--- a/frontend/src/components/panels/payloadShape.test.ts
+++ b/frontend/src/components/panels/payloadShape.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   TOKEN_LABEL,
   VALUE_TOKEN,
+  describeTemplate,
   deriveReadPath,
   extractValue,
   matchTemplate,
@@ -162,5 +163,15 @@ describe("placing the token", () => {
     const placed = placeToken(`${T} C`, 3, 3, "20");
     expect(placed.template).toBe(`20 C${T}`);
     expect(placed.caret).toBe(placed.template.length);
+  });
+});
+
+describe("describeTemplate", () => {
+  it("says the payload the way the editor draws it", () => {
+    expect(describeTemplate(`{"brightness":${VALUE_TOKEN}}`)).toBe(
+      `{"brightness":${TOKEN_LABEL}}`,
+    );
+    expect(describeTemplate(VALUE_TOKEN)).toBe(TOKEN_LABEL);
+    expect(describeTemplate("RESET")).toBe("RESET");
   });
 });

--- a/frontend/src/components/panels/payloadShape.test.ts
+++ b/frontend/src/components/panels/payloadShape.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import {
+  TOKEN_LABEL,
+  VALUE_TOKEN,
+  deriveReadPath,
+  extractValue,
+  matchTemplate,
+  payloadIssue,
+  placeToken,
+  readValue,
+} from "./payloadShape";
+import { parseSliderValue } from "./sliderUtils";
+
+describe("payloadIssue", () => {
+  it("accepts the bare token, which is the default payload", () => {
+    expect(payloadIssue({ template: VALUE_TOKEN })).toBeNull();
+  });
+
+  it("accepts a token wrapped in JSON", () => {
+    expect(
+      payloadIssue({ template: `{"brightness":${VALUE_TOKEN}}` }),
+    ).toBeNull();
+  });
+
+  it("flags a payload the panel's value never reaches", () => {
+    expect(payloadIssue({ template: '{"on":true}' })).toContain(TOKEN_LABEL);
+  });
+
+  it("flags an empty payload on a panel that has a value", () => {
+    expect(payloadIssue({ template: "" })).toBe("No payload configured");
+  });
+
+  it("does not judge the bytes — quoted or not, JSON or not", () => {
+    expect(payloadIssue({ template: `{"state":${VALUE_TOKEN}}` })).toBeNull();
+    expect(payloadIssue({ template: `{"state":"${VALUE_TOKEN}"}` })).toBeNull();
+    expect(payloadIssue({ template: `<set>${VALUE_TOKEN}</set>` })).toBeNull();
+  });
+
+  it("leaves a fixed payload alone, empty included", () => {
+    expect(payloadIssue({ template: "", acceptsToken: false })).toBeNull();
+    expect(payloadIssue({ template: "RESET", acceptsToken: false })).toBeNull();
+  });
+
+  it("flags a token on a panel with no value to put there", () => {
+    expect(
+      payloadIssue({ template: VALUE_TOKEN, acceptsToken: false }),
+    ).toContain(TOKEN_LABEL);
+  });
+
+  it("requires the read shape to mark where the value sits", () => {
+    expect(payloadIssue({ template: '{"v":1}', mode: "read" })).toContain(
+      TOKEN_LABEL,
+    );
+    expect(payloadIssue({ template: VALUE_TOKEN, mode: "read" })).toBeNull();
+  });
+});
+
+describe("JSON-ish payloads", () => {
+  // Firmware that publishes `{temp:22}` is common enough that a panel able to
+  // send that shape has to be able to read it back.
+  it("finds the token's path in a template with unquoted keys", () => {
+    expect(deriveReadPath(`{test:"${VALUE_TOKEN}"}`)).toBe("test");
+    expect(deriveReadPath(`{"test":"${VALUE_TOKEN}"}`)).toBe("test");
+  });
+
+  it("reads a value out of a payload with unquoted keys", () => {
+    expect(extractValue('{test:"50"}', "test").value).toBe(50);
+    expect(extractValue("{temp:22,unit:'C'}", "temp").value).toBe(22);
+  });
+
+  it("tolerates single quotes and a trailing comma", () => {
+    expect(extractValue("{'state':'ON',}", "state").value).toBe(true);
+  });
+
+  it("leaves strict JSON and plain text alone", () => {
+    expect(extractValue('{"a":{"b":7}}', "a.b").value).toBe(7);
+    expect(extractValue("plain text", "a").value).toBe("plain text");
+    expect(extractValue('{"note":"it\'s fine"}', "note").value).toBe(
+      "it's fine",
+    );
+  });
+
+  it("drives the slider round trip end to end", () => {
+    const template = `{test:"${VALUE_TOKEN}"}`;
+    expect(parseSliderValue('{test:"50"}', { template })).toBe(50);
+    expect(parseSliderValue('{test:"nope"}', { template })).toBeNull();
+  });
+});
+
+describe("reading by stencil", () => {
+  // The template already describes the shape, so the message can be read
+  // straight through it without knowing what format it is in.
+  it("reads formats no parser here understands", () => {
+    expect(readValue(`<set>${VALUE_TOKEN}</set>`, "<set>21</set>").value).toBe(
+      21,
+    );
+    expect(readValue(`temp=${VALUE_TOKEN}`, "temp=21.5").value).toBe(21.5);
+    expect(readValue(`${VALUE_TOKEN};ON`, "40;ON").value).toBe(40);
+    expect(readValue(`{test:"${VALUE_TOKEN}"}`, '{test:"50"}').value).toBe(50);
+  });
+
+  it("ignores surrounding whitespace on either side", () => {
+    expect(readValue(`temp=${VALUE_TOKEN}`, "  temp=21\n").value).toBe(21);
+  });
+
+  it("falls back to the path when the message is not that shape", () => {
+    // The device reports more than the panel publishes, so the stencil misses
+    // and the value is located inside the parsed document instead.
+    expect(
+      readValue(`{"brightness":${VALUE_TOKEN}}`, '{"brightness":50,"on":true}')
+        .value,
+    ).toBe(50);
+  });
+
+  it("does not stencil a bare token, which anchors on nothing", () => {
+    expect(matchTemplate(VALUE_TOKEN, "anything")).toBeNull();
+    // It still reads as the whole message, via the path branch
+    expect(readValue(VALUE_TOKEN, "42").value).toBe(42);
+  });
+
+  it("honours a legacy path when the template has no mark", () => {
+    expect(readValue('{"v":1}', '{"state":7}', "state").value).toBe(7);
+  });
+});
+
+describe("placing the token", () => {
+  const T = VALUE_TOKEN;
+
+  it("drops it at a caret, anywhere at all", () => {
+    // Mid-word, which no value-detecting scheme would have offered
+    expect(placeToken("bright", 3, 3).template).toBe(`bri${T}ght`);
+    expect(placeToken('{"b":12}', 5, 5).template).toBe(`{"b":${T}12}`);
+  });
+
+  it("replaces a selection", () => {
+    expect(placeToken('{"b":12}', 5, 7).template).toBe(`{"b":${T}}`);
+    expect(placeToken("SET 20 C", 4, 6).template).toBe(`SET ${T} C`);
+  });
+
+  it("leaves the caret just past the token", () => {
+    const placed = placeToken('{"b":12}', 5, 7);
+    expect(placed.template.slice(0, placed.caret)).toBe(`{"b":${T}`);
+  });
+
+  it("moves an existing token rather than adding a second", () => {
+    const placed = placeToken(`{"a":${T},"b":9}`, 11, 12, "1");
+    expect(placed.template).toBe(`{"a":1,"b":${T}}`);
+    expect(placed.template.split(T)).toHaveLength(2);
+  });
+
+  it("stays put when dropped where it already is", () => {
+    // Repeated taps of the button: the caret sits just past the chip each time
+    let template = `{"b":${T}}`;
+    for (let i = 0; i < 3; i++) {
+      const placed = placeToken(template, 6, 6);
+      expect(placed.template).toBe(`{"b":${T}}`);
+      template = placed.template;
+    }
+  });
+
+  it("accounts for the restored constant when placing the caret", () => {
+    const placed = placeToken(`${T} C`, 3, 3, "20");
+    expect(placed.template).toBe(`20 C${T}`);
+    expect(placed.caret).toBe(placed.template.length);
+  });
+});

--- a/frontend/src/components/panels/payloadShape.ts
+++ b/frontend/src/components/panels/payloadShape.ts
@@ -488,6 +488,11 @@ export function clearToken(template: string, restore: string): string {
   return template.split(VALUE_TOKEN).join(restore);
 }
 
+/** The template as the interface says it, with the token under its label. */
+export function describeTemplate(template: string): string {
+  return template.split(VALUE_TOKEN).join(TOKEN_LABEL);
+}
+
 /**
  * Put the token at a place the user picked, replacing whatever they had
  * selected. A selection of zero width is a caret, so this both inserts and

--- a/frontend/src/components/panels/payloadShape.ts
+++ b/frontend/src/components/panels/payloadShape.ts
@@ -1,0 +1,567 @@
+/**
+ * One description of "how is the value packed into this payload?", used in both
+ * directions: extracting a value out of an incoming message, and building the
+ * payload to publish. Panels used to answer this three different ways (a flat
+ * `valueKey` on the gauge, hand-typed JSON on the toggle, a placeholder
+ * template on the slider); everything now goes through here.
+ */
+
+export type PayloadDataType = "number" | "boolean" | "string";
+
+export interface ExtractedValue {
+  value: string | number | boolean;
+  dataType: PayloadDataType;
+  raw: string;
+}
+
+/**
+ * Keys devices commonly carry the interesting value in. Used to rank path
+ * suggestions so the likely one is offered first.
+ */
+const COMMON_KEYS = [
+  "val",
+  "value",
+  "temp",
+  "temperature",
+  "reading",
+  "status",
+  "state",
+  "data",
+];
+
+/** Strings that read as booleans rather than as text. */
+const TRUE_WORDS = ["true", "on", "yes", "online"];
+const BOOL_WORDS = [...TRUE_WORDS, "false", "off", "no", "offline"];
+
+/**
+ * Walk a dot path (`data.value`, `items.0.temp`) through parsed JSON. Numeric
+ * segments index into arrays. Returns `found: false` rather than undefined so
+ * callers can tell "resolved to null" from "no such path".
+ */
+export function resolvePath(
+  root: unknown,
+  path: string,
+): { found: boolean; value: unknown } {
+  const segments = path
+    .split(".")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (segments.length === 0) return { found: false, value: undefined };
+
+  let current: unknown = root;
+  for (const segment of segments) {
+    if (current === null || current === undefined) {
+      return { found: false, value: undefined };
+    }
+
+    if (Array.isArray(current)) {
+      const index = Number(segment);
+      if (!Number.isInteger(index) || index < 0 || index >= current.length) {
+        return { found: false, value: undefined };
+      }
+      current = current[index];
+      continue;
+    }
+
+    if (typeof current === "object") {
+      const obj = current as Record<string, unknown>;
+      if (!(segment in obj)) return { found: false, value: undefined };
+      current = obj[segment];
+      continue;
+    }
+
+    // Hit a scalar with path left to walk
+    return { found: false, value: undefined };
+  }
+
+  return { found: true, value: current };
+}
+
+/** Coerce an already-unwrapped value into the panel-facing typed form. */
+function coerceValue(target: unknown, raw: string): ExtractedValue {
+  if (typeof target === "number") {
+    return { value: target, dataType: "number", raw };
+  }
+
+  if (typeof target === "boolean") {
+    return { value: target, dataType: "boolean", raw };
+  }
+
+  if (typeof target === "string") {
+    const trimmed = target.trim();
+    const lower = trimmed.toLowerCase();
+
+    if (BOOL_WORDS.includes(lower)) {
+      return { value: TRUE_WORDS.includes(lower), dataType: "boolean", raw };
+    }
+
+    const num = Number(trimmed);
+    if (!isNaN(num) && trimmed !== "") {
+      return { value: num, dataType: "number", raw };
+    }
+
+    return { value: trimmed, dataType: "string", raw };
+  }
+
+  return { value: String(target), dataType: "string", raw };
+}
+
+/**
+ * `JSON.parse`, forgiving of the JSON-ish shapes devices actually publish:
+ * unquoted object keys, single-quoted strings, a trailing comma. Firmware
+ * written by hand emits these constantly, and a panel that refuses to read
+ * `{temp:22}` while happily publishing it is just wrong.
+ *
+ * Strict JSON is tried first, so a well-formed payload is never touched by the
+ * relaxations — they only run on text that has already failed to parse. They
+ * are textual and therefore approximate (an apostrophe inside a double-quoted
+ * string can defeat the single-quote rule); anything they cannot make sense of
+ * comes back as undefined and is read as a whole raw payload, which is what
+ * would have happened anyway.
+ */
+export function parseLooseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    // Fall through to the relaxed attempt
+  }
+
+  const relaxed = text
+    // {temp:22} → {"temp":22}
+    .replace(/([{[,]\s*)([A-Za-z_$][\w$]*)(\s*:)/g, '$1"$2"$3')
+    // {'temp':'on'} → {"temp":"on"}
+    .replace(/'([^'\\]*)'/g, '"$1"')
+    // {"temp":22,} → {"temp":22}
+    .replace(/,(\s*[}\]])/g, "$1");
+
+  try {
+    return JSON.parse(relaxed);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Pull the value at `path` out of a payload.
+ *
+ * Without a path, or when the path does not resolve, the payload is read as a
+ * whole — which for a JSON object means the raw text, matching what panels did
+ * before paths existed.
+ */
+export function extractValue(payload: string, path?: string): ExtractedValue {
+  const raw = payload;
+  let target: unknown;
+
+  const json = parseLooseJson(payload);
+
+  if (json === undefined) {
+    // Not JSON in any reading — treat as the raw payload
+    target = payload;
+  } else {
+    const isArray = Array.isArray(json);
+    const isObject = typeof json === "object" && json !== null && !isArray;
+    const key = path?.trim();
+
+    if (key && (isObject || isArray)) {
+      const resolved = resolvePath(json, key);
+      if (resolved.found) return coerceValue(resolved.value, raw);
+    }
+
+    // No path, or it did not resolve. An object reads as its raw text (there is
+    // no single sensible value to show); anything else reads as the parsed
+    // document — matching what panels did before paths existed.
+    target = isObject ? payload : json;
+  }
+
+  return coerceValue(target, raw);
+}
+
+/**
+ * The payload a panel publishes is written literally, exactly as it goes on the
+ * wire, with a single token marking the one spot the panel's own value drops
+ * into at publish time. Quoting the token is what decides the type: `"◆"` sends
+ * text, a bare `◆` sends a number.
+ */
+export const VALUE_TOKEN = "\u25c6";
+
+/**
+ * What the token is called in the interface. The payload stores the character;
+ * the editor draws it as a chip reading this, and every message about it uses
+ * the same word so they describe the same thing the user can see.
+ */
+export const TOKEN_LABEL = "value";
+
+/** Sentinel used to locate the token inside otherwise-valid JSON. */
+const TOKEN_SENTINEL = "__mqtt_dashboard_token__";
+
+export function hasToken(template: string): boolean {
+  return template.includes(VALUE_TOKEN);
+}
+
+/**
+ * True when the payload is nothing but the token, i.e. the panel publishes its
+ * value on its own with nothing around it. A legitimate, common setup — a bare
+ * slider or button — rather than a payload that happens to lack JSON.
+ */
+export function isBareToken(template: string): boolean {
+  return template.trim() === VALUE_TOKEN;
+}
+
+/** True when the token is written inside quotes, i.e. published as text. */
+export function isTokenQuoted(template: string): boolean {
+  const at = template.indexOf(VALUE_TOKEN);
+  if (at === -1) return false;
+  return template[at - 1] === '"' && template[at + VALUE_TOKEN.length] === '"';
+}
+
+/** Publish-time substitution: the template with the value dropped in. */
+export function renderPayload(
+  template: string,
+  value: string | number | boolean,
+): string {
+  return template.split(VALUE_TOKEN).join(String(value));
+}
+
+/**
+ * The JSON path the token sits at, which is also where the value can be read
+ * back from — the mark is both halves of the shape. Null when the template is
+ * not JSON (the payload is the value) or has no token.
+ */
+export function deriveReadPath(template: string): string | null {
+  if (!hasToken(template)) return null;
+
+  // Make the template parseable by standing a string in for the token; a bare
+  // token needs quotes added, a quoted one already has them.
+  const parseable = isTokenQuoted(template)
+    ? template.split(VALUE_TOKEN).join(TOKEN_SENTINEL)
+    : template.split(VALUE_TOKEN).join(`"${TOKEN_SENTINEL}"`);
+
+  const json = parseLooseJson(parseable);
+
+  if (typeof json !== "object" || json === null) return null;
+
+  const find = (node: unknown, prefix: string): string | null => {
+    if (node === TOKEN_SENTINEL) return prefix;
+
+    if (Array.isArray(node)) {
+      for (let i = 0; i < node.length; i++) {
+        const hit = find(node[i], prefix ? `${prefix}.${i}` : String(i));
+        if (hit !== null) return hit;
+      }
+      return null;
+    }
+
+    if (typeof node === "object" && node !== null) {
+      for (const [key, child] of Object.entries(node)) {
+        const hit = find(child, prefix ? `${prefix}.${key}` : key);
+        if (hit !== null) return hit;
+      }
+    }
+
+    return null;
+  };
+
+  return find(json, "");
+}
+
+/**
+ * Read the value straight out of a message, using the template as a stencil:
+ * everything written before the token has to match, everything after it has to
+ * match, and whatever sits in between is the value.
+ *
+ * This knows nothing about JSON — it reads `<set>21</set>`, `temp=21`, `21;ON`
+ * and `{temp:21}` alike, because the user already described the shape when they
+ * wrote the payload. Returns null when the message is not that shape, which is
+ * the common case of a device reporting more than the panel publishes; those
+ * fall back to the path-based read.
+ *
+ * A bare token anchors on nothing, so it deliberately does not match here — a
+ * whole-message read is what the path branch already does.
+ */
+export function matchTemplate(
+  template: string,
+  message: string,
+): string | null {
+  const at = template.indexOf(VALUE_TOKEN);
+  if (at === -1) return null;
+
+  const prefix = template.slice(0, at).trimStart();
+  const suffix = template.slice(at + VALUE_TOKEN.length).trimEnd();
+  if (!prefix && !suffix) return null;
+
+  const text = message.trim();
+  if (text.length < prefix.length + suffix.length) return null;
+  if (!text.startsWith(prefix) || !text.endsWith(suffix)) return null;
+
+  const candidate = text.slice(prefix.length, text.length - suffix.length);
+
+  // A suffix as generic as `}` matches a message carrying more than the
+  // template describes, swallowing the extra fields into the value. What a
+  // device reports is a scalar, so anything with structure in it means the
+  // stencil caught the wrong span and the path-based read should handle it.
+  if (/[{}[\],:"\n]/.test(candidate)) return null;
+
+  return candidate;
+}
+
+/**
+ * The panel's value, read out of an incoming message.
+ *
+ * The stencil is tried first: it is exact, needs no parser, and works for any
+ * format the device speaks. Only when the message does not fit — extra fields,
+ * a different key order, a shape the panel does not publish — does this fall
+ * back to locating the value by path inside the parsed document.
+ */
+export function readValue(
+  template: string | undefined,
+  message: string,
+  fallbackPath?: string,
+): ExtractedValue {
+  if (template) {
+    const stencilled = matchTemplate(template, message);
+    if (stencilled !== null) return coerceValue(stencilled, message);
+  }
+
+  const path = (template ? deriveReadPath(template) : null) ?? fallbackPath;
+  return extractValue(message, path);
+}
+
+/**
+ * Where a panel reads its value from. A panel whose device reports on a
+ * different shape configures a read template of its own; otherwise incoming
+ * messages are assumed to look like what the panel publishes, so the write
+ * template's token marks the value both ways.
+ *
+ * Panels saved before templates existed have no token to mirror, so their
+ * stored key still applies.
+ */
+export function effectiveReadTemplate(config: {
+  payloadTemplate?: string;
+  readTemplate?: string;
+  separateRead?: boolean;
+}): string | undefined {
+  return config.separateRead && config.readTemplate
+    ? config.readTemplate
+    : config.payloadTemplate;
+}
+
+export function effectiveReadPath(config: {
+  payloadTemplate?: string;
+  readTemplate?: string;
+  separateRead?: boolean;
+  valueKey?: string;
+}): string | undefined {
+  const source =
+    config.separateRead && config.readTemplate
+      ? config.readTemplate
+      : config.payloadTemplate;
+
+  const derived = source ? deriveReadPath(source) : null;
+
+  return derived ?? config.valueKey;
+}
+
+export interface PayloadCheck {
+  /** The payload as configured, token included. */
+  template: string;
+  /**
+   * False for panels with no runtime value (button, cron), where a token would
+   * publish an empty hole instead of standing in for something.
+   */
+  acceptsToken?: boolean;
+  /** "read" checks an incoming shape, where the token marks what to pull out. */
+  mode?: "write" | "read";
+}
+
+/**
+ * The payload problems that leave a panel unable to do its job, phrased for the
+ * header badge and the modal's Save button. Returns null when the payload is
+ * usable; advisory notes (plain text, an empty fixed payload) are not issues —
+ * an empty publish is how a retained message gets cleared.
+ */
+export function payloadIssue({
+  template,
+  acceptsToken = true,
+  mode = "write",
+}: PayloadCheck): string | null {
+  const token = hasToken(template);
+
+  if (mode === "read") {
+    return token
+      ? null
+      : `Read shape does not mark where the ${TOKEN_LABEL} sits`;
+  }
+
+  if (acceptsToken && !token) {
+    return template.trim()
+      ? `Payload has no ${TOKEN_LABEL} in it — every publish would send the same bytes`
+      : "No payload configured";
+  }
+
+  if (!acceptsToken && token) {
+    return `This panel has no ${TOKEN_LABEL} to send — remove it from the payload`;
+  }
+
+  // The bytes themselves are never judged: a payload that is not JSON, or is
+  // JSON-shaped without parsing, is a device's business and not a broken panel.
+  return null;
+}
+
+export interface TemplateLiteral {
+  text: string;
+  start: number;
+  end: number;
+}
+
+/**
+ * Value literals in the template, each of which the user can move the token
+ * onto. Matches JSON values after a colon; a template that is a bare value with
+ * no token counts as one literal so it can be marked too.
+ */
+export function findLiterals(template: string): TemplateLiteral[] {
+  const out: TemplateLiteral[] = [];
+  const re = /:\s*("(?:[^"\\]|\\.)*"|-?\d+(?:\.\d+)?|true|false)/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(template)) !== null) {
+    const start = match.index + match[0].length - match[1].length;
+    out.push({ text: match[1], start, end: start + match[1].length });
+  }
+
+  const trimmed = template.trim();
+  if (out.length === 0 && trimmed !== "" && !hasToken(template)) {
+    const start = template.indexOf(trimmed);
+    out.push({ text: trimmed, start, end: start + trimmed.length });
+  }
+
+  return out.filter((lit) => !lit.text.includes(VALUE_TOKEN));
+}
+
+/**
+ * Move the token onto `literal`. Only one token may exist, so wherever it was
+ * gets a constant handed back — the value it held before it was marked.
+ */
+export function markLiteral(
+  template: string,
+  literal: TemplateLiteral,
+  restore: string,
+): { template: string; previous: string } {
+  const quoted = literal.text.startsWith('"');
+  const previous = quoted ? literal.text.slice(1, -1) : literal.text;
+
+  let next =
+    template.slice(0, literal.start) +
+    (quoted ? `"${VALUE_TOKEN}"` : VALUE_TOKEN) +
+    template.slice(literal.end);
+
+  // Index of the token we just placed, so the older ones can be filled back in
+  const keepAt = quoted ? literal.start + 1 : literal.start;
+
+  const positions: number[] = [];
+  let at = next.indexOf(VALUE_TOKEN);
+  while (at !== -1) {
+    positions.push(at);
+    at = next.indexOf(VALUE_TOKEN, at + 1);
+  }
+
+  for (let i = positions.length - 1; i >= 0; i--) {
+    if (positions[i] === keepAt) continue;
+    next =
+      next.slice(0, positions[i]) +
+      restore +
+      next.slice(positions[i] + VALUE_TOKEN.length);
+  }
+
+  return { template: next, previous };
+}
+
+/**
+ * Drop the token, putting the constant it replaced back where it was.
+ *
+ * A payload that is *only* the token empties instead: there is no surrounding
+ * message for a constant to sit in, and leaving one behind would silently turn
+ * "publish my value" into "publish this one literal forever".
+ */
+export function clearToken(template: string, restore: string): string {
+  if (isBareToken(template)) return "";
+  return template.split(VALUE_TOKEN).join(restore);
+}
+
+/**
+ * Put the token at a place the user picked, replacing whatever they had
+ * selected. A selection of zero width is a caret, so this both inserts and
+ * replaces depending on what they did.
+ *
+ * Only one token can exist, so a token already sitting elsewhere hands its spot
+ * back to the constant it displaced — the same trade `clearToken` makes.
+ * Returns where the caret belongs afterwards, just past the token.
+ */
+export function placeToken(
+  template: string,
+  start: number,
+  end: number,
+  restore = "",
+): { template: string; caret: number } {
+  const untoken = (part: string) => part.split(VALUE_TOKEN).join(restore);
+
+  const before = untoken(template.slice(0, start));
+  const after = untoken(template.slice(end));
+
+  return {
+    template: before + VALUE_TOKEN + after,
+    caret: before.length + VALUE_TOKEN.length,
+  };
+}
+
+/**
+ * Leaf paths present in a JSON payload, likely candidates first, so the config
+ * modals can offer them instead of making the user guess the shape.
+ */
+export function suggestPaths(payload: string, maxDepth = 3): string[] {
+  const json = parseLooseJson(payload);
+
+  if (typeof json !== "object" || json === null) return [];
+
+  const paths: string[] = [];
+
+  const walk = (node: unknown, prefix: string, depth: number) => {
+    if (paths.length >= 24 || depth > maxDepth) return;
+
+    if (Array.isArray(node)) {
+      // Sampling the first element is enough to show the shape
+      if (node.length > 0) walk(node[0], `${prefix}.0`, depth + 1);
+      return;
+    }
+
+    if (typeof node === "object" && node !== null) {
+      for (const [key, child] of Object.entries(node)) {
+        const next = prefix ? `${prefix}.${key}` : key;
+        if (typeof child === "object" && child !== null) {
+          walk(child, next, depth + 1);
+        } else {
+          paths.push(next);
+        }
+      }
+      return;
+    }
+
+    if (prefix) paths.push(prefix);
+  };
+
+  walk(json, "", 0);
+
+  // Common names first, then shallower paths, then alphabetical for stability
+  return paths.sort((a, b) => {
+    const rank = (p: string) => {
+      const leaf = p.split(".").pop() ?? p;
+      const idx = COMMON_KEYS.indexOf(leaf.toLowerCase());
+      return idx === -1 ? COMMON_KEYS.length : idx;
+    };
+    const byRank = rank(a) - rank(b);
+    if (byRank !== 0) return byRank;
+    const byDepth = a.split(".").length - b.split(".").length;
+    if (byDepth !== 0) return byDepth;
+    return a.localeCompare(b);
+  });
+}

--- a/frontend/src/components/panels/registry.test.tsx
+++ b/frontend/src/components/panels/registry.test.tsx
@@ -22,9 +22,9 @@ afterEach(() => {
 });
 
 describe("Panel Registry", () => {
-  it("registers all 10 built-in panels by default", () => {
+  it("registers all 11 built-in panels by default", () => {
     const panels = getAllPanels();
-    expect(panels.length).toBeGreaterThanOrEqual(10);
+    expect(panels.length).toBeGreaterThanOrEqual(11);
 
     const types = panels.map((p) => p.type);
     expect(types).toContain("gauge");
@@ -34,6 +34,7 @@ describe("Panel Registry", () => {
     expect(types).toContain("input");
     expect(types).toContain("cron");
     expect(types).toContain("toggle");
+    expect(types).toContain("slider");
     expect(types).toContain("text");
     expect(types).toContain("separator");
     expect(types).toContain("image");
@@ -47,7 +48,7 @@ describe("Panel Registry", () => {
 
     const controls = getPanelsByCategory("control").map((p) => p.type);
     expect(controls).toEqual(
-      expect.arrayContaining(["button", "input", "cron", "toggle"]),
+      expect.arrayContaining(["button", "input", "cron", "toggle", "slider"]),
     );
     expect(controls).not.toContain("gauge");
     expect(controls).not.toContain("image");

--- a/frontend/src/components/panels/registry.test.tsx
+++ b/frontend/src/components/panels/registry.test.tsx
@@ -21,6 +21,28 @@ afterEach(() => {
   cleanup();
 });
 
+describe("Slider header meta", () => {
+  const slider = () => getPanelDefinition("slider");
+
+  it("shows the payload, as the config modal does", () => {
+    expect(
+      slider()?.getHeaderMeta?.({ topic: "lamp", payloadTemplate: '{"b":◆}' })
+        ?.payloadPreview,
+    ).toBe('{"b":value}');
+  });
+
+  it("shows both shapes when the panel reads from elsewhere", () => {
+    expect(
+      slider()?.getHeaderMeta?.({
+        topic: "lamp",
+        payloadTemplate: "◆",
+        separateRead: true,
+        readTemplate: '{"bri":◆}',
+      })?.payloadPreview,
+    ).toBe('sends  value\nreads  {"bri":value}');
+  });
+});
+
 describe("Panel Registry", () => {
   it("registers all 11 built-in panels by default", () => {
     const panels = getAllPanels();

--- a/frontend/src/components/panels/sliderUtils.ts
+++ b/frontend/src/components/panels/sliderUtils.ts
@@ -1,0 +1,84 @@
+import { readValue } from "./payloadShape";
+
+export const DEFAULT_MIN = 0;
+export const DEFAULT_MAX = 100;
+export const DEFAULT_STEP = 1;
+
+export interface SliderRange {
+  min: number;
+  max: number;
+  step: number;
+}
+
+/**
+ * Fall back to the defaults for anything missing or non-finite, and keep the
+ * range usable: an inverted or empty range would make the track undraggable.
+ */
+export function normalizeRange(config: {
+  min?: number;
+  max?: number;
+  step?: number;
+}): SliderRange {
+  const min = Number.isFinite(config.min) ? Number(config.min) : DEFAULT_MIN;
+  const rawMax = Number.isFinite(config.max) ? Number(config.max) : DEFAULT_MAX;
+  const max = rawMax > min ? rawMax : min + 1;
+
+  const rawStep = Number.isFinite(config.step)
+    ? Number(config.step)
+    : DEFAULT_STEP;
+  const step = rawStep > 0 ? rawStep : DEFAULT_STEP;
+
+  return { min, max, step };
+}
+
+/**
+ * Snap a value onto the configured range. Steps are counted from `min` so a
+ * range like 10..30 step 5 yields 10/15/20/…, and the result is rounded to the
+ * step's own precision to avoid 0.30000000000000004 showing up in a payload.
+ */
+export function clampToRange(value: number, range: SliderRange): number {
+  const { min, max, step } = range;
+  if (!Number.isFinite(value)) return min;
+  if (value <= min) return min;
+  if (value >= max) return max;
+
+  const snapped = min + Math.round((value - min) / step) * step;
+  const decimals = decimalsOf(step);
+  const rounded = Number(snapped.toFixed(decimals));
+
+  return Math.min(max, Math.max(min, rounded));
+}
+
+function decimalsOf(step: number): number {
+  const text = String(step);
+  const dot = text.indexOf(".");
+  return dot === -1 ? 0 : text.length - dot - 1;
+}
+
+/**
+ * Read a slider position out of an incoming payload, using the panel's own
+ * payload shape to find it. Returns null when the payload holds no number, so
+ * the panel can show "unknown" instead of snapping the handle to an invented
+ * position.
+ */
+export function parseSliderValue(
+  payload: string,
+  shape: { template?: string; path?: string } = {},
+): number | null {
+  const { value, dataType } = readValue(
+    shape.template,
+    payload,
+    shape.path?.trim() || undefined,
+  );
+  if (dataType !== "number") return null;
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** Position as a 0..1 fraction of the range, for the filled track. */
+export function valueToFraction(value: number, range: SliderRange): number {
+  const span = range.max - range.min;
+  if (span <= 0) return 0;
+  return Math.min(1, Math.max(0, (value - range.min) / span));
+}

--- a/frontend/src/components/panels/tokenEditor.ts
+++ b/frontend/src/components/panels/tokenEditor.ts
@@ -65,7 +65,10 @@ export function readTemplate(host: Node): string {
     }
 
     if (node.tagName === "BR") {
-      out += "\n";
+      // Browsers park a filler <br> at the end of editable content to keep the
+      // last line reachable. It is not a line the user typed, and publishing
+      // the newline it stands for would append a byte they cannot see.
+      if (!isTrailingFiller(node, host)) out += "\n";
       return;
     }
 
@@ -79,6 +82,18 @@ export function readTemplate(host: Node): string {
   host.childNodes.forEach(walk);
 
   return out;
+}
+
+/** True for a <br> with nothing after it, anywhere up to the host. */
+function isTrailingFiller(node: Node, host: Node): boolean {
+  let current: Node | null = node;
+
+  while (current && current !== host) {
+    if (current.nextSibling) return false;
+    current = current.parentNode;
+  }
+
+  return true;
 }
 
 /**
@@ -138,7 +153,13 @@ export function setCaret(host: HTMLElement, offset: number): void {
       continue;
     }
 
-    // A chip is one character wide, and the caret can only sit beside it
+    // A chip is one character wide, and the caret can only sit beside it: on
+    // its leading edge that means before it, past it means after.
+    if (offset <= seen) {
+      range.setStart(host, index);
+      placed = true;
+      break;
+    }
     seen += 1;
     if (offset <= seen) {
       range.setStart(host, index + 1);

--- a/frontend/src/components/panels/tokenEditor.ts
+++ b/frontend/src/components/panels/tokenEditor.ts
@@ -1,0 +1,155 @@
+import { TOKEN_LABEL, VALUE_TOKEN } from "./payloadShape";
+
+/**
+ * The payload editor is a contenteditable rather than a textarea, so the token
+ * can be a chip the user reads as "the panel's value" instead of a lone glyph
+ * they have to be told about. These two functions are the whole contract:
+ * `paintTemplate` turns the stored string into DOM, `readTemplate` turns the
+ * DOM back into the string. Everything between them is the browser's own text
+ * editing.
+ */
+
+/** Marks the chip, so it reads back as the token and is never typed into. */
+export const TOKEN_ATTR = "data-value-token";
+
+const CHIP_CLASS =
+  "inline-flex items-center h-5 px-2 mx-0.5 align-middle rounded-full " +
+  "border border-primary bg-primary/15 text-primary font-mono text-[11px] " +
+  "select-none";
+
+/** Replace the host's content with the template, token rendered as a chip. */
+export function paintTemplate(host: HTMLElement, template: string): void {
+  const nodes: Node[] = [];
+
+  template.split(VALUE_TOKEN).forEach((chunk, index) => {
+    if (index > 0) nodes.push(buildChip(host.ownerDocument));
+    if (chunk) nodes.push(host.ownerDocument.createTextNode(chunk));
+  });
+
+  host.replaceChildren(...nodes);
+}
+
+function buildChip(doc: Document): HTMLElement {
+  const chip = doc.createElement("span");
+  chip.setAttribute(TOKEN_ATTR, "");
+  // Atomic: the caret cannot land inside it, and backspace removes the whole
+  // chip rather than eating one letter of the word "value".
+  chip.setAttribute("contenteditable", "false");
+  chip.className = CHIP_CLASS;
+  chip.textContent = TOKEN_LABEL;
+  return chip;
+}
+
+/**
+ * Read the host back as a payload string. Browsers represent a newline in a
+ * contenteditable as a `<br>` or as a fresh block element depending on how it
+ * was produced, so both are mapped back to "\n".
+ */
+export function readTemplate(host: Node): string {
+  let out = "";
+
+  const walk = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      out += node.textContent ?? "";
+      return;
+    }
+
+    if (!(node instanceof HTMLElement)) return;
+
+    if (node.hasAttribute(TOKEN_ATTR)) {
+      // Browsers do not always remove the whole chip: some empty it out and
+      // leave the husk behind. A chip that no longer reads as itself has been
+      // deleted, whatever the DOM still holds.
+      if (node.textContent === TOKEN_LABEL) out += VALUE_TOKEN;
+      return;
+    }
+
+    if (node.tagName === "BR") {
+      out += "\n";
+      return;
+    }
+
+    // A block element starts a line, unless we are already at the start of one
+    const isBlock = node.tagName === "DIV" || node.tagName === "P";
+    if (isBlock && out && !out.endsWith("\n")) out += "\n";
+
+    node.childNodes.forEach(walk);
+  };
+
+  host.childNodes.forEach(walk);
+
+  return out;
+}
+
+/**
+ * Where the selection sits, counted in payload characters rather than DOM
+ * positions — the chip counts as the single token character it stands for.
+ * Measured by cloning the content up to each end and reading it back, so it
+ * holds up whatever shape the browser has made of the box.
+ *
+ * Null when nothing in the editor is selected, e.g. the user has not put the
+ * caret in it yet.
+ */
+export function readSelectionOffsets(
+  host: HTMLElement,
+): { start: number; end: number } | null {
+  const selection = host.ownerDocument.getSelection();
+  if (!selection || selection.rangeCount === 0) return null;
+
+  const range = selection.getRangeAt(0);
+  if (!host.contains(range.commonAncestorContainer)) return null;
+
+  const upTo = (container: Node, offset: number) => {
+    const measured = host.ownerDocument.createRange();
+    measured.selectNodeContents(host);
+    measured.setEnd(container, offset);
+    return readTemplate(measured.cloneContents()).length;
+  };
+
+  return {
+    start: upTo(range.startContainer, range.startOffset),
+    end: upTo(range.endContainer, range.endOffset),
+  };
+}
+
+/**
+ * Put the caret at a payload offset. Only valid on a freshly painted box, whose
+ * children are a flat run of text nodes and chips.
+ */
+export function setCaret(host: HTMLElement, offset: number): void {
+  const selection = host.ownerDocument.getSelection();
+  if (!selection) return;
+
+  const range = host.ownerDocument.createRange();
+  let seen = 0;
+  let placed = false;
+
+  for (let index = 0; index < host.childNodes.length; index++) {
+    const node = host.childNodes[index];
+
+    if (node.nodeType === Node.TEXT_NODE) {
+      const length = node.textContent?.length ?? 0;
+      if (offset <= seen + length) {
+        range.setStart(node, offset - seen);
+        placed = true;
+        break;
+      }
+      seen += length;
+      continue;
+    }
+
+    // A chip is one character wide, and the caret can only sit beside it
+    seen += 1;
+    if (offset <= seen) {
+      range.setStart(host, index + 1);
+      placed = true;
+      break;
+    }
+  }
+
+  if (!placed) range.setStart(host, host.childNodes.length);
+
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}

--- a/frontend/src/hooks/usePayloadSample.ts
+++ b/frontend/src/hooks/usePayloadSample.ts
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react";
+import { api } from "../api/client";
+import { suggestPaths } from "../components/panels/payloadShape";
+
+export interface RecentMessage {
+  payload: string;
+  /** Relative age for display, e.g. "2s", "4m", "1d". */
+  ago: string;
+}
+
+export interface PayloadSample {
+  /** Raw payload of the most recent historic message, if any. */
+  payload: string | null;
+  /** Most recent messages, newest first — what the device actually sends. */
+  recent: RecentMessage[];
+  /** Dot paths present in the newest payload, likely candidates first. */
+  suggestedPaths: string[];
+  loading: boolean;
+}
+
+/** Compact relative age: 2s, 4m, 3h, 1d. */
+function ago(timestamp: string): string {
+  const then = new Date(timestamp).getTime();
+  if (Number.isNaN(then)) return "";
+
+  const seconds = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86400)}d`;
+}
+
+/**
+ * Fetch the latest message on a topic so a config modal can show what the
+ * payload actually looks like and offer the paths inside it.
+ *
+ * Extracted from the gauge modal, which was the only panel doing this. Callers
+ * pass the topic string as typed; only the first of a comma-separated list is
+ * sampled, since a shape only makes sense for one topic.
+ *
+ * The result is stored tagged with the broker/topic it came from, so `loading`
+ * and `payload` are derived rather than synchronised — state is only ever set
+ * from the fetch callback, never synchronously inside the effect.
+ */
+export function usePayloadSample(
+  brokerId: string,
+  topic: string,
+  limit = 3,
+): PayloadSample {
+  const [result, setResult] = useState<{
+    source: string;
+    recent: RecentMessage[];
+  } | null>(null);
+
+  const singleTopic = topic.split(",")[0]?.trim() ?? "";
+  const source = `${brokerId}\u0000${singleTopic}`;
+  const canSample = Boolean(brokerId && singleTopic);
+
+  useEffect(() => {
+    if (!canSample) return;
+
+    let cancelled = false;
+
+    api
+      .getExplorerHistory(brokerId, singleTopic)
+      .then((records) => {
+        if (cancelled) return;
+
+        const newest = records
+          ? [...records]
+              .sort(
+                (a, b) =>
+                  new Date(b.timestamp).getTime() -
+                  new Date(a.timestamp).getTime(),
+              )
+              .slice(0, limit)
+              .map((r) => ({ payload: r.payload, ago: ago(r.timestamp) }))
+          : [];
+
+        setResult({ source, recent: newest });
+      })
+      .catch(() => {
+        if (!cancelled) setResult({ source, recent: [] });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [brokerId, singleTopic, source, canSample, limit]);
+
+  // Ignore a result belonging to a broker/topic the caller has since changed
+  const fresh = result?.source === source ? result : null;
+  const recent = fresh?.recent ?? [];
+  const payload = recent[0]?.payload ?? null;
+
+  return {
+    payload,
+    recent,
+    suggestedPaths: payload ? suggestPaths(payload) : [],
+    loading: canSample && fresh === null,
+  };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -34,3 +34,43 @@
 .status-dot-hover-hint {
   animation: status-dot-hover-hint 2.2s ease-out infinite;
 }
+
+/*
+ * A range whose handle is a circle riding a hairline.
+ *
+ * daisyUI ties the track to half the thumb, and paints the filled part as a
+ * box-shadow spreading out of the thumb itself — so the "track" is really
+ * thumb-height whatever the track rule says. Turning `--range-fill` off drops
+ * that shadow, and the progress is painted on the track instead, as a gradient
+ * stopping at `--range-progress-x`.
+ *
+ * Deliberately unlayered: daisyUI's own rules sit in a cascade layer, and
+ * unlayered styles outrank every layer regardless of order.
+ */
+.range-hairline::-webkit-slider-runnable-track {
+  height: var(--track-size, 4px);
+  border-radius: 9999px;
+  background: linear-gradient(
+    to right,
+    currentColor 0 var(--range-progress-x, 0%),
+    var(--range-bg) var(--range-progress-x, 0%) 100%
+  );
+}
+
+.range-hairline::-moz-range-track {
+  height: var(--track-size, 4px);
+  border-radius: 9999px;
+  background: linear-gradient(
+    to right,
+    currentColor 0 var(--range-progress-x, 0%),
+    var(--range-bg) var(--range-progress-x, 0%) 100%
+  );
+}
+
+.range-hairline::-webkit-slider-thumb {
+  border-radius: 9999px;
+}
+
+.range-hairline::-moz-range-thumb {
+  border-radius: 9999px;
+}


### PR DESCRIPTION
Adds a **Slider** control panel: publishes a numeric position to a command topic and reflects the value the device actually reports, reusing the toggle's optimistic write, 5s confirmation timeout and status footer.

## Describing the payload once, for both directions

There is no payload format to choose. You type the bytes your device expects and mark the one spot the position drops into — a `value` chip you can drop at the caret, or over a selection to replace it:

```
◆              →  50
{"brightness":◆}  →  {"brightness":50}
<set>◆</set>   →  <set>50</set>
```

That same mark is where the value is **read back** from, so the shape is described once. Incoming messages are matched against the template as a stencil — no parser, any format — and only fall back to locating the value by path inside the parsed document when the device reports more than the panel publishes (`{"brightness":50,"on":true}`).

A payload with no `value` in it, or a `value` on a panel that has none, blocks Save and raises the header warning badge, the same way a missing topic does. The bytes themselves are never judged: non-JSON payloads are a device's business.

## Panel

- Range, step and unit; the handle is a circle riding a hairline track, both scaling with the panel
- Double-click the readout to type a value; it snaps onto the range
- Optional separate state topic, on its own broker, with its own read shape
- One publish per adjustment — dragging only moves the handle locally

## Shared groundwork

`payloadShape.ts` (shape, validation, stencil), `PayloadBuilder` + `tokenEditor` (the editor and its chip), `ReadBackSection` and `usePayloadSample` are written for reuse. Migrating gauge/toggle/button/cron onto them is a follow-up PR, kept out of this one deliberately.

## Testing

`npx tsc --noEmit`, `npx eslint src`, `npx prettier --check`, and 132 tests pass (11 files), including the payload stencil and path fallback, token placement and removal, the contenteditable chip's DOM round trip, and the slider's publish rules.

Not verified: anything needing a real browser — caret behaviour around the chip, and the slider's track/thumb rendering across engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UdDTQUGuaZ6d5F1owCwiB