### PR TITLE
chore(dev): keep frontend node_modules out of the mounted worktree

### DIFF
--- a/docker/dev/Dockerfile.dev
+++ b/docker/dev/Dockerfile.dev
@@ -5,18 +5,28 @@ RUN apk add --no-cache git curl nodejs npm
 # Install air for hot reload
 RUN go install github.com/air-verse/air@latest
 
-WORKDIR /app
-
 # Copy go mod files and download deps
+WORKDIR /app
 COPY ./backend/go.mod ./backend/go.sum ./backend/
 RUN cd backend && go mod download
 
-# Copy frontend package files and install
-COPY ./frontend/package*.json ./frontend/
-RUN cd frontend && npm ci
+# Frontend deps live in /node_modules, outside the /app bind mount: Node walks
+# up from /app/frontend and finds them there. Keeping them off the mounted tree
+# means the host worktree never gets a node_modules directory (so `git worktree
+# remove` stays clean) and there is no named volume to go stale when the
+# lockfile changes.
+WORKDIR /
+COPY ./frontend/package.json ./frontend/package-lock.json /
+RUN npm ci --no-audit --no-fund && md5sum < /package-lock.json > /node_modules/.lock-hash
+ENV PATH="/node_modules/.bin:${PATH}"
+# Vite defaults its cache to <root>/node_modules/.vite, which would recreate the
+# directory we just moved away; entrypoint.sh points it at /node_modules/.vite.
+ENV VITE_CACHE_DIR=/node_modules/.vite
 
+WORKDIR /app
 COPY . .
 
 EXPOSE 8080 5173
 
-CMD ["sh", "-c", "cd frontend && npm run dev -- --host & cd backend && air"]
+COPY ./docker/dev/entrypoint.sh /entrypoint.sh
+CMD ["/entrypoint.sh"]

--- a/docker/dev/docker-compose-dev.yml
+++ b/docker/dev/docker-compose-dev.yml
@@ -12,8 +12,6 @@ services:
       context: ../..
     volumes:
       - ../..:/app
-      # Shadow host node_modules with container-built Linux binaries
-      - frontend_node_modules:/app/frontend/node_modules
     environment:
       - APP_ENV=development
       - LOG_LEVEL=debug
@@ -85,9 +83,6 @@ services:
       - TLS_CA_CERT=/certs/ca.crt
       - TLS_CLIENT_CERT=/certs/client.crt
       - TLS_CLIENT_KEY=/certs/client.key
-
-volumes:
-  frontend_node_modules:
 
 networks:
   # Implicit per-project bridge: brokers + worker + app, isolated per worktree

--- a/docker/dev/entrypoint.sh
+++ b/docker/dev/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Dev container entrypoint: keep /node_modules in sync with the mounted
+# lockfile, then run Vite and air side by side.
+set -e
+
+# Nothing masks /node_modules any more, and Node resolves the nearest
+# node_modules first — a host-side `npm install` would shadow the container's
+# Linux binaries with macOS ones. Fail loudly rather than crash inside Vite.
+if [ -n "$(ls -A /app/frontend/node_modules 2>/dev/null)" ]; then
+    echo "ERROR: frontend/node_modules exists in the worktree and would shadow" >&2
+    echo "       the container's deps in /node_modules. Remove it on the host:" >&2
+    echo "         rm -rf frontend/node_modules" >&2
+    exit 1
+fi
+
+LOCK=/app/frontend/package-lock.json
+HASH_FILE=/node_modules/.lock-hash
+
+# The image installs deps at build time, but the worktree is bind-mounted, so a
+# branch switch or a pull can bring in a lockfile the image was never built
+# against. Reinstall when that happens instead of serving a stale tree (which
+# shows up as missing platform binaries, e.g. lightningcss-linux-arm64-musl).
+if [ ! -f "$HASH_FILE" ] || [ "$(md5sum < "$LOCK")" != "$(cat "$HASH_FILE")" ]; then
+    echo "==> frontend: package-lock.json changed, reinstalling /node_modules..."
+    cp /app/frontend/package.json "$LOCK" /
+    (cd / && npm ci --no-audit --no-fund)
+    md5sum < "$LOCK" > "$HASH_FILE"
+fi
+
+cd /app/frontend && npm run dev -- --host &
+cd /app/backend && exec air

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,10 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  // Defaults to <root>/node_modules/.vite. The dev container keeps node_modules
+  // outside the bind-mounted worktree, so it overrides this (see
+  // docker/dev/Dockerfile.dev); everywhere else the default applies.
+  cacheDir: process.env.VITE_CACHE_DIR,
   define: {
     "process.env.NODE_ENV": JSON.stringify(
       process.env.NODE_ENV ?? "production",


### PR DESCRIPTION
The dev container installed frontend deps into `/app/frontend/node_modules` and shadowed them with a named volume. Two problems:

- a `node_modules` directory appeared inside the bind-mounted worktree — enough for `git worktree remove` to refuse
- the volume went stale whenever the lockfile changed, surfacing as missing platform binaries (`lightningcss-linux-arm64-musl`) rather than as anything legible

## What changed

Deps install to **`/node_modules`** instead. Node walks up from `/app/frontend` and finds them there, so nothing is mounted over the worktree and there is no volume to go stale — the `frontend_node_modules` volume is gone.

Vite defaults its cache to `<root>/node_modules/.vite`, which would recreate the very directory we moved away, so it is pointed at `/node_modules/.vite` via `VITE_CACHE_DIR` (`vite.config.ts` reads it; unset everywhere else, so the default still applies outside the container).

A new `docker/dev/entrypoint.sh` keeps the image honest against the mounted tree:

- compares `package-lock.json`'s hash against the one recorded at build time and reinstalls when a branch switch or a pull brings in a different one
- refuses to start when `frontend/node_modules` exists on the host, since Node would resolve those macOS binaries before the container's Linux ones, with an error saying exactly what to remove

## Testing

Ran the dev container against this worktree throughout the slider work: Vite and air both start, a lockfile change triggers the reinstall path, and the worktree stays free of `node_modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UdDTQUGuaZ6d5F1owCwiB