### PR TITLE
fix(frontend): correct cron step matching, cron search cost, and topic filter wildcards

### DIFF
--- a/frontend/src/components/explorer/topicFilterUtils.ts
+++ b/frontend/src/components/explorer/topicFilterUtils.ts
@@ -7,6 +7,31 @@
  * - If query includes MQTT wildcards ('+' for single level, '#' for multi-level) or glob ('*'),
  *   matches topic structure accordingly.
  */
+
+// Translate a filter into a regex source, expanding each wildcard exactly once.
+function filterToRegexSource(filter: string): string {
+  let rest = filter;
+  // In MQTT, `a/#` matches the parent topic `a` as well, so the trailing
+  // `/#` compiles to an optional group.
+  const parentMatch = rest.endsWith("/#");
+  if (parentMatch) {
+    rest = rest.slice(0, -2);
+  }
+
+  let source = "";
+  for (const char of rest) {
+    if (char === "+") {
+      source += "[^/]+";
+    } else if (char === "#" || char === "*") {
+      source += ".*";
+    } else {
+      source += char.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+  }
+
+  return parentMatch ? `${source}(?:/.*)?` : source;
+}
+
 export function topicMatchesFilter(topic: string, filter: string): boolean {
   const q = filter.trim();
   if (!q) return true;
@@ -22,18 +47,7 @@ export function topicMatchesFilter(topic: string, filter: string): boolean {
   // If query contains wildcards (+ or # or *)
   if (q.includes("+") || q.includes("#") || q.includes("*")) {
     try {
-      const escaped = lowerFilter
-        .replace(/[.+^${}()|[\]\\]/g, (char) => {
-          if (char === "+" || char === "^" || char === "$") {
-            return char === "+" ? "+" : `\\${char}`;
-          }
-          return `\\${char}`;
-        })
-        .replace(/\+/g, "[^/]+")
-        .replace(/#/g, ".*")
-        .replace(/\*/g, ".*");
-
-      const regex = new RegExp(`^${escaped}$`, "i");
+      const regex = new RegExp(`^${filterToRegexSource(lowerFilter)}$`, "i");
       if (regex.test(lowerTopic)) {
         return true;
       }

--- a/frontend/src/components/panels/cronUtils.ts
+++ b/frontend/src/components/panels/cronUtils.ts
@@ -61,12 +61,14 @@ export function describeCron(expr: string): string | null {
   }
 }
 
-function matchCronPart(val: number, part: string): boolean {
+function matchCronPart(val: number, part: string, fieldMin: number): boolean {
   if (part === "*") return true;
   const [range, stepStr] = part.split("/");
   const step = stepStr ? parseInt(stepStr, 10) : 1;
   if (range === "*") {
-    return val % step === 0;
+    // Cron counts steps from the field's minimum, which is 1 for day of month
+    // and month, not 0.
+    return (val - fieldMin) % step === 0;
   }
   if (range.includes("-")) {
     const [minStr, maxStr] = range.split("-");
@@ -78,52 +80,79 @@ function matchCronPart(val: number, part: string): boolean {
   return parseInt(range, 10) === val;
 }
 
-function matchCronField(val: number, fieldExpr: string): boolean {
-  return fieldExpr.split(",").some((part) => matchCronPart(val, part));
+function matchCronField(
+  val: number,
+  fieldExpr: string,
+  fieldMin: number,
+): boolean {
+  return fieldExpr
+    .split(",")
+    .some((part) => matchCronPart(val, part, fieldMin));
+}
+
+const [MINUTE, HOUR, DOM, MONTH, DOW] = CRON_FIELDS;
+
+// Minute and hour fields only.
+function matchesCronTime(parts: string[], date: Date): boolean {
+  return (
+    matchCronField(date.getMinutes(), parts[0], MINUTE.min) &&
+    matchCronField(date.getHours(), parts[1], HOUR.min)
+  );
+}
+
+// Day-of-month, month and weekday fields only.
+function matchesCronDate(parts: string[], date: Date): boolean {
+  const [, , domExpr, monthExpr, dowExpr] = parts;
+  if (!matchCronField(date.getMonth() + 1, monthExpr, MONTH.min)) return false;
+
+  const dom = date.getDate();
+  const dow = date.getDay();
+  const domIsStar = domExpr === "*";
+  const dowIsStar = dowExpr === "*";
+  if (!domIsStar && !dowIsStar) {
+    return (
+      matchCronField(dom, domExpr, DOM.min) ||
+      matchCronField(dow, dowExpr, DOW.min)
+    );
+  }
+  return (
+    matchCronField(dom, domExpr, DOM.min) &&
+    matchCronField(dow, dowExpr, DOW.min)
+  );
 }
 
 export function matchesCron(expr: string, date: Date): boolean {
   const parts = expr.trim().split(/\s+/);
   if (parts.length !== 5) return false;
-  const [minExpr, hourExpr, domExpr, monthExpr, dowExpr] = parts;
-
-  const min = date.getMinutes();
-  const hour = date.getHours();
-  const dom = date.getDate();
-  const month = date.getMonth() + 1;
-  const dow = date.getDay();
-
-  if (!matchCronField(min, minExpr)) return false;
-  if (!matchCronField(hour, hourExpr)) return false;
-  if (!matchCronField(month, monthExpr)) return false;
-
-  const domIsStar = domExpr === "*";
-  const dowIsStar = dowExpr === "*";
-  if (!domIsStar && !dowIsStar) {
-    if (!matchCronField(dom, domExpr) && !matchCronField(dow, dowExpr)) {
-      return false;
-    }
-  } else {
-    if (!matchCronField(dom, domExpr)) return false;
-    if (!matchCronField(dow, dowExpr)) return false;
-  }
-
-  return true;
+  return matchesCronTime(parts, date) && matchesCronDate(parts, date);
 }
 
 export function getPreviousCronRun(expr: string, nextRun: Date): Date | null {
-  const target = new Date(nextRun.getTime());
-  target.setSeconds(0, 0);
+  // Expressions this parser cannot handle (@daily, "MON", 7 for Sunday, ...)
+  // would otherwise never match and run the whole search on the UI thread.
+  if (validateCron(expr) !== null) return null;
+  const parts = expr.trim().split(/\s+/);
 
-  // Look backwards up to 366 days (527040 minutes)
-  const maxMinutes = 527040;
-  let curr = new Date(target.getTime() - 60000);
+  const curr = new Date(nextRun.getTime());
+  curr.setSeconds(0, 0);
+  curr.setTime(curr.getTime() - 60000);
 
-  for (let i = 0; i < maxMinutes; i++) {
-    if (matchesCron(expr, curr)) {
-      return curr;
+  // Look backwards up to 366 days.
+  const limit = new Date(curr.getTime());
+  limit.setDate(limit.getDate() - 366);
+
+  while (curr.getTime() >= limit.getTime()) {
+    // Skip whole days that the date fields rule out, so an expression that
+    // never matches (e.g. "0 0 30 2 *") costs 366 steps instead of 527040.
+    if (!matchesCronDate(parts, curr)) {
+      curr.setDate(curr.getDate() - 1);
+      curr.setHours(23, 59, 0, 0);
+      continue;
     }
-    curr = new Date(curr.getTime() - 60000);
+    if (matchesCronTime(parts, curr)) {
+      return new Date(curr.getTime());
+    }
+    curr.setTime(curr.getTime() - 60000);
   }
   return null;
 }


### PR DESCRIPTION
Fixes #154, #155 and #156 — three pre-existing bugs found during review of #153.

### #154 — `*/N` steps counted from 0 instead of the field minimum

`matchCronPart` returned `val % step === 0` for a `*/step` part. Cron counts steps from the field's *minimum*, which is 1 for day of month and month, so those two fields were off by one: `0 0 */2 * *` reported days 2, 4, 6… while the job actually runs on 1, 3, 5….

The `*` branch now takes the field's minimum and uses `(val - fieldMin) % step === 0`, the same form the `a-b` branch already used. Minutes and hours are unaffected (minimum 0), which is why this hid in the common presets.

### #155 — `getPreviousCronRun` could spin 527k iterations on the main thread

The search walked backwards one minute at a time for up to 366 days, allocating a `Date` each step, and any expression the Go scheduler accepts but this parser does not (`@daily`, `0 0 * * MON`, `0 0 * * 7`) ran it to exhaustion — on the UI thread, on every 30s poll.

Two guards:

- It returns `null` immediately when `validateCron` rejects the expression, so unsupported expressions cost nothing.
- Matching is split into date fields and time fields, and the search skips a whole day when the date fields rule it out. A valid-but-never-matching expression like `0 0 30 2 *` now costs 366 steps instead of 527,040, and ordinary expressions get the same speedup.

`matchesCron` keeps its signature and behavior, now composed from the two halves.

### #156 — topic filter expanded `#` twice, and `a/#` did not match `a`

The chained substitutions rewrote the `*` emitted by the `#` replacement, so `sensors/#` compiled to `^sensors/..*$` — at least one character after the slash.

Wildcards are now expanded in a single character scan (`+` → `[^/]+`, `#`/`*` → `.*`), with regex specials escaped inline. A trailing `/#` compiles to `(?:/.*)?`, so `sensors/#` matches `sensors`, `sensors/` and `sensors/a/b`, as MQTT specifies.

### Verification

- `tsc -b --noEmit` and `eslint` clean; Prettier clean.
- Full frontend suite passes (200 tests).
- Wrote 11 targeted cases reproducing each issue's examples from the reports — all passed — then removed the file, since `AGENTS.md` asks for no new frontend tests unless requested. Happy to add them if you'd like them kept.

Note: the branch was 15 commits behind and was fast-forwarded to `main` first — `topicFilterUtils.ts` did not exist at the old tip.

https://claude.ai/code/session_01TRwhSxw9ocsNFnFmZaUFux
