### PR TITLE
feat(panels): add graph panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - **Drag & Drop Dashboard** — Build your own control center with resizable, draggable panels using a responsive grid layout engine
 - **Multi-Dashboard Support** — Create multiple dashboard tabs, rename, delete, and import/export dashboards as JSON files with starter templates
 - **Functional & Visual Panels** — Button (with confirmation option), Input, Log, Cron, Broker Stats, Image (URL or upload), Separator, and Markdown Text panels
-- **Topic Explorer + Wildcards** — Browse collapsible MQTT topic trees, inspect message history, navigate with breadcrumbs, and subscribe with `+` and `#` patterns
+- **Topic Explorer + Wildcards** — Browse collapsible MQTT topic trees, inspect message history and a live graph of numeric values, navigate with breadcrumbs, and subscribe with `+` and `#` patterns
 - **Message History & Retention** — Persistent history in SQLite with configurable retention periods, manual cleanup controls, and automated background pruning
 - **Multi-Broker Management** — Connect to multiple MQTT brokers concurrently, reorder priority, and monitor live telemetry & `$SYS` metrics
 - **TLS & Authentication** — Supports plain TCP, TLS/SSL (with CA cert upload or skip-verify), username/password, and mutual TLS (client certificate & key)
@@ -124,6 +124,7 @@ go build -o mqtt-dashboard .
 | **Input** | Type and send ad-hoc messages to any topic with configurable QoS and Retain flags |
 | **Toggle** | Switch a device on/off and reflect its real state from a command or separate telemetry topic, with configurable on/off payloads |
 | **Log** | Real-time message stream with persistent history, wildcards, QoS/Retain badges, and date formatting |
+| **Graph** | Numeric payloads plotted over time, seeded from stored history, with one line per topic matched by a wildcard, selectable time window, and hover readout |
 | **Cron** | Scheduled automatic publishing with visual cron builder helper, next-run countdown, and toggle switch |
 | **Stats** | Live broker statistics and message activity charts ($SYS telemetry, memory, client counts) |
 

--- a/docker/dev/config.json
+++ b/docker/dev/config.json
@@ -30,97 +30,202 @@
   ],
   "dashboards": [
     {
-      "id": "dev-showcase",
-      "name": "Dev Showcase",
+      "id": "showcase-monitors",
+      "name": "Showcase · Monitors",
       "panels": [
         {
-          "title": "🧪 Developer Showcase",
+          "title": "📈 Monitors",
           "panel_type": "text",
           "x": 0,
           "y": 0,
           "w": 12,
-          "h": 2,
+          "h": 3,
           "config_json": {
-            "markdown": "# 🧪 Developer Showcase Dashboard\n\nComprehensive test suite featuring all **9 panel types** and configurations:\n- **Monitors**: Radial / Bar / Value Gauges, Topic Throughput Stats, Streaming Live Logs\n- **Controls**: Instant & Confirmation Action Buttons, Dynamic Input, Automated Cron\n- **Visuals**: Separator Dividers, Rich Markdown, Architecture Media Cards\n\n> 💡 *Live feeds connected to `mosquitto` with simulated IoT & control topics.*"
+            "markdown": "## 📈 Monitors — every read-only panel type\n\nFed by the dev worker's `demo/` namespace on **Mosquitto Plain** (one point per\nsecond, so the graphs actually draw). Each group has a **debug log** beneath it\nshowing the exact messages its panels are reading — if a panel looks wrong, the\nlog says whether the data or the config is at fault.\n\n| Group | Panel types | Topics |\n| --- | --- | --- |\n| Gauges | `gauge` × 3 types | `demo/thermostat/measured`, `demo/graph/humidity`, `demo/lamp/state`, `demo/fan/state` |\n| Graphs | `graph` × 3 curves | `demo/graph/#` |\n| Stats | `stats` × 2 | `demo/#`, `sensors/#` |\n"
           }
         },
         {
-          "title": "Section Divider",
-          "panel_type": "separator",
-          "x": 0,
-          "y": 2,
-          "w": 12,
-          "h": 1,
-          "config_json": {
-            "orientation": "horizontal",
-            "thickness": 2,
-            "color": "#9ca3af"
-          }
-        },
-        {
-          "title": "Temperature (Radial Dial)",
+          "title": "Thermostat (radial)",
           "panel_type": "gauge",
           "x": 0,
           "y": 3,
           "w": 3,
-          "h": 3,
+          "h": 4,
           "config_json": {
-            "topic": "sensors/living-room/temperature",
-            "valueKey": "value",
+            "topic": "demo/thermostat/measured",
+            "readTemplate": "{\"value\": {value}, \"unit\": \"°C\"}",
             "unit": "°C",
-            "min": 0,
-            "max": 50,
+            "min": 5,
+            "max": 30,
             "colorScheme": "auto",
             "gaugeType": "radial",
-            "header_meta_pinned": false
+            "header_meta_pinned": true
           },
           "broker_name": "Mosquitto Plain"
         },
         {
-          "title": "Humidity (Progress Bar)",
+          "title": "Humidity (bar)",
           "panel_type": "gauge",
           "x": 3,
           "y": 3,
           "w": 3,
-          "h": 3,
+          "h": 4,
           "config_json": {
-            "topic": "sensors/living-room/humidity",
-            "valueKey": "value",
+            "topic": "demo/graph/humidity",
+            "readTemplate": "{\"value\": {value}, \"unit\": \"%\"}",
             "unit": "%",
             "min": 0,
             "max": 100,
-            "colorScheme": "auto",
+            "colorScheme": "info",
             "gaugeType": "bar",
-            "header_meta_pinned": false
+            "header_meta_pinned": true
           },
           "broker_name": "Mosquitto Plain"
         },
         {
-          "title": "Motion Detector (Value Card)",
+          "title": "Lamp (value card)",
           "panel_type": "gauge",
           "x": 6,
           "y": 3,
           "w": 3,
-          "h": 3,
+          "h": 4,
           "config_json": {
-            "topic": "sensors/living-room/motion",
-            "valueKey": "value",
-            "unit": "",
+            "topic": "demo/lamp/state",
+            "readTemplate": "{value}",
             "gaugeType": "value",
-            "header_meta_pinned": false
+            "colorScheme": "success",
+            "header_meta_pinned": true
           },
           "broker_name": "Mosquitto Plain"
         },
         {
-          "title": "Sensor Metrics & Rate",
-          "panel_type": "stats",
+          "title": "Fan speed (legacy valueKey)",
+          "panel_type": "gauge",
           "x": 9,
           "y": 3,
           "w": 3,
+          "h": 4,
+          "config_json": {
+            "topic": "demo/fan/state",
+            "valueKey": "speed",
+            "unit": "%",
+            "min": 0,
+            "max": 100,
+            "colorScheme": "warning",
+            "gaugeType": "radial",
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "🔍 Gauge feeds (debug)",
+          "panel_type": "log",
+          "x": 0,
+          "y": 7,
+          "w": 12,
           "h": 3,
           "config_json": {
-            "topic": "sensors/#",
-            "defaultRange": 60,
+            "topics": "demo/thermostat/measured, demo/graph/humidity, demo/lamp/state, demo/fan/state",
+            "maxMessages": 100,
+            "dateFormat": "time",
+            "showQos": true,
+            "showRetained": true,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "Climate (smooth, area, legend)",
+          "panel_type": "graph",
+          "x": 0,
+          "y": 10,
+          "w": 6,
+          "h": 5,
+          "config_json": {
+            "topics": "demo/graph/temperature, demo/graph/humidity",
+            "readTemplate": "{\"value\": {value}}",
+            "timeWindowSeconds": 300,
+            "maxPoints": 600,
+            "curve": "smooth",
+            "showArea": true,
+            "showPoints": false,
+            "showLegend": true,
+            "yMin": null,
+            "yMax": null,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "Power draw (step, fixed axis)",
+          "panel_type": "graph",
+          "x": 6,
+          "y": 10,
+          "w": 3,
+          "h": 5,
+          "config_json": {
+            "topics": "demo/graph/power",
+            "readTemplate": "{value}",
+            "unit": "W",
+            "timeWindowSeconds": 180,
+            "maxPoints": 300,
+            "curve": "step",
+            "showArea": true,
+            "showPoints": false,
+            "showLegend": false,
+            "yMin": 0,
+            "yMax": 3000,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "Flaky feed (linear, points)",
+          "panel_type": "graph",
+          "x": 9,
+          "y": 10,
+          "w": 3,
+          "h": 5,
+          "config_json": {
+            "topics": "demo/graph/mixed",
+            "readTemplate": "{value}",
+            "timeWindowSeconds": 120,
+            "maxPoints": 150,
+            "curve": "linear",
+            "showArea": false,
+            "showPoints": true,
+            "showLegend": false,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "🔍 Graph feeds (debug) — note the non-numeric messages the chart skips",
+          "panel_type": "log",
+          "x": 0,
+          "y": 15,
+          "w": 12,
+          "h": 3,
+          "config_json": {
+            "topics": "demo/graph/#",
+            "maxMessages": 300,
+            "dateFormat": "full",
+            "showQos": true,
+            "showRetained": true,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "Showcase throughput (all sections)",
+          "panel_type": "stats",
+          "x": 0,
+          "y": 18,
+          "w": 6,
+          "h": 5,
+          "config_json": {
+            "topic": "demo/#",
+            "defaultRange": 300,
             "showStatTiles": true,
             "showChart": true,
             "showTopicBreakdown": true,
@@ -129,126 +234,306 @@
           "broker_name": "Mosquitto Plain"
         },
         {
-          "title": "Section Divider",
-          "panel_type": "separator",
+          "title": "Sensor throughput (tiles only)",
+          "panel_type": "stats",
+          "x": 6,
+          "y": 18,
+          "w": 6,
+          "h": 5,
+          "config_json": {
+            "topic": "sensors/#",
+            "defaultRange": 3600,
+            "showStatTiles": true,
+            "showChart": false,
+            "showTopicBreakdown": false,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        }
+      ]
+    },
+    {
+      "id": "showcase-controls",
+      "name": "Showcase · Controls",
+      "panels": [
+        {
+          "title": "🎛️ Controls",
+          "panel_type": "text",
+          "x": 0,
+          "y": 0,
+          "w": 12,
+          "h": 3,
+          "config_json": {
+            "markdown": "## 🎛️ Controls — every panel type that publishes\n\nThe dev worker **answers these**: it subscribes to each command topic below,\napplies it to a simulated device, republishes the device's retained state, and\nechoes a line to `demo/events`. So a toggle really does turn something on, and\nthe state you read back is the device's, not the panel's own optimism.\n\n| Panel | Publishes to | Reads back from |\n| --- | --- | --- |\n| Toggles | `demo/lamp/set` | `demo/lamp/state` (`ON` / `OFF`) |\n| Sliders | `demo/fan/set`, `demo/thermostat/set` | `demo/fan/state`, `demo/thermostat/state` (JSON) |\n| Buttons / Input | `demo/actions/+`, `test/command` | `demo/events` |\n| Cron | `test/heartbeat`, `demo/actions/sweep` | `demo/events` |\n\nThe **debug logs** at the bottom show both directions at once: what the panel\nsent, and what the worker did with it.\n"
+          }
+        },
+        {
+          "title": "Lamp (command only)",
+          "panel_type": "toggle",
+          "x": 0,
+          "y": 3,
+          "w": 3,
+          "h": 3,
+          "config_json": {
+            "topic": "demo/lamp/set",
+            "onPayload": "ON",
+            "offPayload": "OFF",
+            "qos": 0,
+            "retain": false,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "Lamp (reads demo/lamp/state)",
+          "panel_type": "toggle",
+          "x": 3,
+          "y": 3,
+          "w": 3,
+          "h": 3,
+          "config_json": {
+            "topic": "demo/lamp/set",
+            "separateRead": true,
+            "stateTopic": "demo/lamp/state",
+            "readTemplate": "{value}",
+            "onPayload": "ON",
+            "offPayload": "OFF",
+            "qos": 1,
+            "retain": false,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "Lamp (JSON write shape)",
+          "panel_type": "toggle",
+          "x": 6,
+          "y": 3,
+          "w": 3,
+          "h": 3,
+          "config_json": {
+            "topic": "demo/lamp/set",
+            "separateRead": true,
+            "stateTopic": "demo/lamp/state",
+            "readTemplate": "{value}",
+            "onPayload": "ON",
+            "offPayload": "OFF",
+            "payloadTemplate": "{\"state\": \"{value}\", \"src\": \"dashboard\"}",
+            "qos": 2,
+            "retain": true,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "Lamp state (mirror)",
+          "panel_type": "gauge",
+          "x": 9,
+          "y": 3,
+          "w": 3,
+          "h": 3,
+          "config_json": {
+            "topic": "demo/lamp/state",
+            "readTemplate": "{value}",
+            "gaugeType": "value",
+            "colorScheme": "accent",
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "🔍 Toggle: commands out, state back (debug)",
+          "panel_type": "log",
           "x": 0,
           "y": 6,
           "w": 12,
-          "h": 1,
+          "h": 3,
           "config_json": {
-            "orientation": "horizontal",
-            "thickness": 2,
-            "color": "#9ca3af"
-          }
+            "topics": "demo/lamp/set, demo/lamp/state",
+            "maxMessages": 100,
+            "dateFormat": "full",
+            "showQos": true,
+            "showRetained": true,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
         },
         {
-          "title": "Start Node (Action Button)",
-          "panel_type": "button",
+          "title": "Fan speed (bare number)",
+          "panel_type": "slider",
           "x": 0,
-          "y": 7,
-          "w": 3,
-          "h": 3,
-          "config_json": {
-            "label": "Start Node",
-            "topic": "device/1/cmd",
-            "payload": "START",
-            "qos": 1,
-            "retain": false,
-            "header_meta_pinned": false
-          },
-          "broker_name": "Mosquitto Plain"
-        },
-        {
-          "title": "Stop Node (Action Button)",
-          "panel_type": "button",
-          "x": 3,
-          "y": 7,
-          "w": 3,
-          "h": 3,
-          "config_json": {
-            "label": "Stop Node",
-            "topic": "device/1/cmd",
-            "payload": "STOP",
-            "qos": 1,
-            "retain": false,
-            "header_meta_pinned": false
-          },
-          "broker_name": "Mosquitto Plain"
-        },
-        {
-          "title": "Quick Boost (Custom Payload)",
-          "panel_type": "button",
-          "x": 6,
-          "y": 7,
-          "w": 3,
-          "h": 3,
-          "config_json": {
-            "label": "Boost Fan",
-            "topic": "sensors/bathroom/humidity",
-            "payload": "{\"action\": \"boost\", \"speed\": 100}",
-            "qos": 1,
-            "retain": false,
-            "header_meta_pinned": false
-          },
-          "broker_name": "Mosquitto Plain"
-        },
-        {
-          "title": "Emergency Cut (Confirmed)",
-          "panel_type": "button",
-          "x": 9,
-          "y": 7,
-          "w": 3,
-          "h": 3,
-          "config_json": {
-            "label": "Emergency Stop",
-            "topic": "device/1/cmd",
-            "payload": "{\"action\": \"emergency_stop\"}",
-            "qos": 1,
-            "retain": false,
-            "requireConfirm": true,
-            "header_meta_pinned": false
-          },
-          "broker_name": "Mosquitto Plain"
-        },
-        {
-          "title": "Section Divider",
-          "panel_type": "separator",
-          "x": 0,
-          "y": 10,
-          "w": 12,
-          "h": 1,
-          "config_json": {
-            "orientation": "horizontal",
-            "thickness": 2,
-            "color": "#9ca3af"
-          }
-        },
-        {
-          "title": "Custom Command Publisher",
-          "panel_type": "input",
-          "x": 0,
-          "y": 11,
+          "y": 9,
           "w": 4,
           "h": 3,
           "config_json": {
-            "topic": "test/command",
+            "topic": "demo/fan/set",
+            "separateRead": true,
+            "stateTopic": "demo/fan/state",
+            "readTemplate": "{\"speed\": {value}, \"unit\": \"%\"}",
+            "min": 0,
+            "max": 100,
+            "step": 5,
+            "unit": "%",
             "qos": 0,
             "retain": false,
-            "header_meta_pinned": false
+            "header_meta_pinned": true
           },
           "broker_name": "Mosquitto Plain"
         },
         {
-          "title": "Heartbeat Scheduler",
+          "title": "Thermostat (JSON write shape)",
+          "panel_type": "slider",
+          "x": 4,
+          "y": 9,
+          "w": 4,
+          "h": 3,
+          "config_json": {
+            "topic": "demo/thermostat/set",
+            "separateRead": true,
+            "stateTopic": "demo/thermostat/state",
+            "readTemplate": "{\"setpoint\": {value}}",
+            "payloadTemplate": "{\"setpoint\": {value}}",
+            "min": 5,
+            "max": 30,
+            "step": 0.5,
+            "unit": "°C",
+            "qos": 1,
+            "retain": true,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "Fan speed (mirror)",
+          "panel_type": "gauge",
+          "x": 8,
+          "y": 9,
+          "w": 4,
+          "h": 3,
+          "config_json": {
+            "topic": "demo/fan/state",
+            "readTemplate": "{\"speed\": {value}, \"unit\": \"%\"}",
+            "unit": "%",
+            "min": 0,
+            "max": 100,
+            "gaugeType": "bar",
+            "colorScheme": "primary",
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "🔍 Slider: commands out, state back (debug)",
+          "panel_type": "log",
+          "x": 0,
+          "y": 12,
+          "w": 12,
+          "h": 3,
+          "config_json": {
+            "topics": "demo/fan/set, demo/fan/state, demo/thermostat/set, demo/thermostat/state",
+            "maxMessages": 100,
+            "dateFormat": "full",
+            "showQos": true,
+            "showRetained": true,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "Ping (plain)",
+          "panel_type": "button",
+          "x": 0,
+          "y": 15,
+          "w": 3,
+          "h": 3,
+          "config_json": {
+            "label": "Ping",
+            "topic": "demo/actions/ping",
+            "payload": "ping",
+            "qos": 0,
+            "retain": false,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "Reboot (confirmation)",
+          "panel_type": "button",
+          "x": 3,
+          "y": 15,
+          "w": 3,
+          "h": 3,
+          "config_json": {
+            "label": "Reboot node",
+            "topic": "demo/actions/reboot",
+            "payload": "{\"action\": \"reboot\", \"delay\": 5}",
+            "qos": 1,
+            "retain": false,
+            "requireConfirm": true,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "Latch (QoS 2, retained)",
+          "panel_type": "button",
+          "x": 6,
+          "y": 15,
+          "w": 3,
+          "h": 3,
+          "config_json": {
+            "label": "Latch relay",
+            "topic": "demo/actions/latch",
+            "payload": "LATCHED",
+            "qos": 2,
+            "retain": true,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "Free-text command",
+          "panel_type": "input",
+          "x": 9,
+          "y": 15,
+          "w": 3,
+          "h": 3,
+          "config_json": {
+            "topic": "test/command",
+            "placeholder": "Type a command and press enter…",
+            "qos": 1,
+            "retain": false,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "Retained note",
+          "panel_type": "input",
+          "x": 0,
+          "y": 18,
+          "w": 4,
+          "h": 3,
+          "config_json": {
+            "topic": "demo/actions/note",
+            "placeholder": "Stored on the broker as retained",
+            "qos": 0,
+            "retain": true,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "Heartbeat (enabled)",
           "panel_type": "cron",
           "x": 4,
-          "y": 11,
+          "y": 18,
           "w": 4,
           "h": 3,
           "config_json": {
             "cron_expr": "* * * * *",
             "topic": "test/heartbeat",
-            "payload": "{\"status\": \"healthy\", \"timestamp\": \"auto\"}",
+            "payload": "{\"status\": \"healthy\", \"from\": \"cron panel\"}",
             "qos": 0,
             "retain": false,
             "enabled": true,
@@ -257,14 +542,32 @@
           "broker_name": "Mosquitto Plain"
         },
         {
-          "title": "Live IoT & Test Feed",
-          "panel_type": "log",
+          "title": "Nightly sweep (disabled)",
+          "panel_type": "cron",
           "x": 8,
-          "y": 11,
+          "y": 18,
           "w": 4,
           "h": 3,
           "config_json": {
-            "topics": "sensors/#, test/#",
+            "cron_expr": "30 2 * * *",
+            "topic": "demo/actions/sweep",
+            "payload": "sweep",
+            "qos": 1,
+            "retain": false,
+            "enabled": false,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        },
+        {
+          "title": "🔍 Commands out (debug)",
+          "panel_type": "log",
+          "x": 0,
+          "y": 21,
+          "w": 6,
+          "h": 4,
+          "config_json": {
+            "topics": "demo/actions/#, test/command, test/heartbeat",
             "maxMessages": 200,
             "dateFormat": "full",
             "showQos": true,
@@ -274,39 +577,121 @@
           "broker_name": "Mosquitto Plain"
         },
         {
-          "title": "Section Divider",
-          "panel_type": "separator",
-          "x": 0,
-          "y": 14,
-          "w": 12,
-          "h": 1,
+          "title": "🔍 Worker replies — demo/events (debug)",
+          "panel_type": "log",
+          "x": 6,
+          "y": 21,
+          "w": 6,
+          "h": 4,
           "config_json": {
-            "orientation": "horizontal",
-            "thickness": 2,
-            "color": "#9ca3af"
+            "topics": "demo/events",
+            "maxMessages": 200,
+            "dateFormat": "full",
+            "showQos": true,
+            "showRetained": true,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
+        }
+      ]
+    },
+    {
+      "id": "showcase-layout",
+      "name": "Showcase · Layout",
+      "panels": [
+        {
+          "title": "🧱 Layout",
+          "panel_type": "text",
+          "x": 0,
+          "y": 0,
+          "w": 12,
+          "h": 3,
+          "config_json": {
+            "markdown": "## 🧱 Layout — the panel types with no broker at all\n\n`text`, `separator` and `image` never subscribe or publish. They are here so the\nshowcase covers all **12 panel types**, and so the markdown renderer has\nsomething to chew on.\n"
           }
         },
         {
-          "title": "Architecture Blueprint",
-          "panel_type": "image",
+          "title": "Horizontal rule",
+          "panel_type": "separator",
           "x": 0,
-          "y": 15,
+          "y": 3,
+          "w": 12,
+          "h": 1,
+          "config_json": {
+            "orientation": "horizontal"
+          }
+        },
+        {
+          "title": "Markdown reference",
+          "panel_type": "text",
+          "x": 0,
+          "y": 4,
+          "w": 5,
+          "h": 6,
+          "config_json": {
+            "markdown": "### Markdown support\n\nEverything `react-markdown` renders, in one panel:\n\n1. **Bold**, *italic*, ~~struck~~, and `inline code`\n2. A [link back to the explorer](/explorer)\n3. A fenced block:\n\n```json\n{\"value\": 21.4, \"unit\": \"°C\"}\n```\n\n| Panel | Category | Broker |\n| --- | --- | --- |\n| gauge | monitor | yes |\n| separator | layout | no |\n\n> Blockquotes work too — handy for the notes at the top of a dashboard.\n\n---\n\n- [x] Task lists\n- [ ] …including unchecked ones\n"
+          }
+        },
+        {
+          "title": "Vertical rule",
+          "panel_type": "separator",
+          "x": 5,
+          "y": 4,
+          "w": 1,
+          "h": 6,
+          "config_json": {
+            "orientation": "vertical"
+          }
+        },
+        {
+          "title": "Image panel",
+          "panel_type": "image",
+          "x": 6,
+          "y": 4,
           "w": 6,
-          "h": 3,
+          "h": 6,
           "config_json": {
             "src": "https://images.unsplash.com/photo-1558494949-ef010cbdcc31?auto=format&fit=crop&w=1200&q=80"
           }
         },
         {
-          "title": "System Notes & Guide",
+          "title": "Horizontal rule",
+          "panel_type": "separator",
+          "x": 0,
+          "y": 10,
+          "w": 12,
+          "h": 1,
+          "config_json": {
+            "orientation": "horizontal"
+          }
+        },
+        {
+          "title": "Notes",
           "panel_type": "text",
-          "x": 6,
-          "y": 15,
+          "x": 0,
+          "y": 11,
           "w": 6,
           "h": 3,
           "config_json": {
-            "markdown": "### 🛠️ Developer Tips & Controls\n\n- **Drag & Resize**: Click **Edit: ON** in the header to reorder or resize panels.\n- **Topic Explorer**: Use the search icon in any config modal to browse topics.\n- **QoS & Retain**: Configure per-panel Quality of Service and retained flags.\n- **Multiple Brokers**: Easily switch brokers per panel (Plain, Password, TLS)."
+            "markdown": "### Re-seeding\n\nThese dashboards are seeded from `docker/dev/config.json` **only when a dashboard of that name has no panels**. To pick up edits, delete the dev database (`backend/data/mqtt-dashboard.db`) and restart the stack."
           }
+        },
+        {
+          "title": "🔍 Raw feed — everything the plain broker sees (debug)",
+          "panel_type": "log",
+          "x": 6,
+          "y": 11,
+          "w": 6,
+          "h": 3,
+          "config_json": {
+            "topics": "#",
+            "maxMessages": 500,
+            "dateFormat": "time",
+            "showQos": true,
+            "showRetained": true,
+            "header_meta_pinned": true
+          },
+          "broker_name": "Mosquitto Plain"
         }
       ]
     }

--- a/docker/dev/docker-compose-dev.yml
+++ b/docker/dev/docker-compose-dev.yml
@@ -12,6 +12,13 @@ services:
       context: ../..
     volumes:
       - ../..:/app
+    # Deps live in /node_modules (see Dockerfile.dev), but Node still resolves
+    # /app/frontend/node_modules first, and both sides keep recreating it: the
+    # host editor writes .tmp/*.tsbuildinfo there, Vite writes .vite-temp. An
+    # empty tmpfs hides whatever the host has and sends those writes to RAM, so
+    # the worktree stays clean and nothing shadows the container's Linux builds.
+    tmpfs:
+      - /app/frontend/node_modules
     environment:
       - APP_ENV=development
       - LOG_LEVEL=debug

--- a/docker/dev/docker-compose-dev.yml
+++ b/docker/dev/docker-compose-dev.yml
@@ -78,7 +78,10 @@ services:
     volumes:
       - ./mosquitto/certs:/certs:ro
     environment:
+      # sensors/ and test/ rounds; the showcase demo/ series tick faster so the
+      # graph panels have a line to draw rather than a point every few minutes.
       - PUBLISH_INTERVAL=5
+      - DEMO_INTERVAL=1
       - BROKER_PLAIN_HOST=mosquitto
       - BROKER_PLAIN_PORT=1883
       - BROKER_PASS_HOST=mosquitto-password

--- a/docker/dev/entrypoint.sh
+++ b/docker/dev/entrypoint.sh
@@ -3,14 +3,14 @@
 # lockfile, then run Vite and air side by side.
 set -e
 
-# Nothing masks /node_modules any more, and Node resolves the nearest
-# node_modules first — a host-side `npm install` would shadow the container's
-# Linux binaries with macOS ones. Fail loudly rather than crash inside Vite.
+# Node resolves the nearest node_modules first, so a host-side `npm install`
+# would shadow the container's Linux binaries with macOS ones. Compose masks
+# /app/frontend/node_modules with an empty tmpfs to prevent that; warn rather
+# than exit if it is populated anyway (mask dropped, or `docker run` by hand).
 if [ -n "$(ls -A /app/frontend/node_modules 2>/dev/null)" ]; then
-    echo "ERROR: frontend/node_modules exists in the worktree and would shadow" >&2
-    echo "       the container's deps in /node_modules. Remove it on the host:" >&2
-    echo "         rm -rf frontend/node_modules" >&2
-    exit 1
+    echo "WARNING: /app/frontend/node_modules is not empty — the tmpfs mask in" >&2
+    echo "         docker-compose-dev.yml is missing, and these deps will shadow" >&2
+    echo "         the container's own in /node_modules." >&2
 fi
 
 LOCK=/app/frontend/package-lock.json

--- a/docker/dev/worker/README.md
+++ b/docker/dev/worker/README.md
@@ -6,12 +6,47 @@ Test message publisher for MQTT Dashboard development and integration testing.
 
 The test worker is included in the development Docker Compose stack (`docker/dev/docker-compose-dev.yml`) to continuously publish realistic telemetry and test payloads to the three dev Mosquitto brokers (`mosquitto`, `mosquitto-password`, `mosquitto-tls`).
 
-Two publishing profiles run concurrently:
+Three publishing profiles run concurrently:
 
-- **IoT Simulator**: Generates realistic sensor telemetry (temperature, humidity, pressure, motion, light) on `sensors/<room>/<metric>` topics with JSON payloads containing timestamps and units.
-- **Simple Payloads**: Incrementing counters, random numbers, and status strings on `test/<topic>` topics (e.g. `test/topic1`, `test/counter`, `test/status`).
+- **IoT Simulator** (all brokers): Generates realistic sensor telemetry (temperature, humidity, pressure, motion, light) on `sensors/<room>/<metric>` topics with JSON payloads containing timestamps and units. One random topic per round.
+- **Simple Payloads** (all brokers): Incrementing counters, random numbers, and status strings on `test/<topic>` topics (e.g. `test/topic1`, `test/counter`, `test/status`).
+- **Showcase Device** (plain broker only): The `demo/` namespace behind the seeded showcase dashboards — smooth series for the graph panels, and simulated devices that **answer the commands the control panels publish**. Without it, a toggle or slider has nowhere to publish and never reads a state back.
 
-Both profiles randomly assign QoS levels (0, 1, 2) and Retain flags to test broker and dashboard behavior.
+The first two profiles randomly assign QoS levels (0, 1, 2) and Retain flags to test broker and dashboard behavior. The showcase stays on one broker on purpose: it ticks once a second, and triplicating it would fill the history database with three copies of every point.
+
+---
+
+## The `demo/` namespace
+
+### Telemetry — published every `DEMO_INTERVAL`
+
+| Topic | Payload | For |
+| --- | --- | --- |
+| `demo/graph/temperature` | `{"value": 21.4, "unit": "°C", "timestamp": …}` | graph, gauge |
+| `demo/graph/humidity` | `{"value": 48.2, "unit": "%", "timestamp": …}` | graph, gauge |
+| `demo/graph/power` | `1240` (bare number) | graph with no read shape |
+| `demo/graph/mixed` | mostly numbers, ~1 in 8 is `n/a` / `error` | the graph's "nothing numeric here" path |
+| `demo/thermostat/measured` | `{"value": 21.4, "unit": "°C"}` | gauge, graph |
+| `demo/house/summary` | every device in one JSON document | payload-shape experiments |
+
+Values are a bounded random walk, not an independent draw per tick — a graph of uniform noise says nothing about whether the chart works.
+
+### Devices — command in, retained state out
+
+The worker subscribes to each command topic, applies it to a simulated device, republishes that device's **retained** state, and echoes a line to `demo/events`.
+
+| Command topic | Accepted payloads | State topic (retained) |
+| --- | --- | --- |
+| `demo/lamp/set` | `ON` / `OFF` (also `true`, `1`, `yes`…) bare, or wrapped: `{"state": "ON"}` | `demo/lamp/state` → `ON` / `OFF` |
+| `demo/fan/set` | a number, bare or as `{"value": …}` / `{"speed": …}` | `demo/fan/state` → `{"speed": 40, "unit": "%"}` |
+| `demo/thermostat/set` | a number, bare or as `{"setpoint": …}` | `demo/thermostat/state` → `{"setpoint": 21, "measured": 20.4, "unit": "°C"}` |
+| `demo/actions/+` | anything — button, cron and retained-input targets | *(no device; logged only)* |
+| `test/command` | anything — the free-text input panel | *(no device; logged only)* |
+| `test/heartbeat` | anything — the cron panel | *(no device; logged only)* |
+
+`demo/events` carries `{"topic", "payload", "result", "timestamp"}` for **every** command received, including ones that changed nothing — which is the interesting case when a control panel looks like it is doing nothing. Point a log panel at it.
+
+The thermostat's measured temperature chases its setpoint rather than jumping, so moving the slider draws a curve on the graph.
 
 ---
 
@@ -19,16 +54,29 @@ Both profiles randomly assign QoS levels (0, 1, 2) and Retain flags to test brok
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
-| `PUBLISH_INTERVAL` | `5` | Seconds between publish rounds |
+| `PUBLISH_INTERVAL` | `5` | Seconds between `sensors/` and `test/` rounds |
+| `DEMO_INTERVAL` | `1` | Seconds between `demo/` telemetry ticks |
 | `BROKER_PLAIN_HOST` | `mosquitto` | Host for anonymous plain TCP broker |
 | `BROKER_PLAIN_PORT` | `1883` | Port for anonymous plain TCP broker |
 | `BROKER_PASS_HOST` | `mosquitto-password` | Host for password-authenticated broker |
-| `BROKER_PASS_PORT` | `1883` | Port for password-authenticated broker |
+| `BROKER_PASS_PORT` | `1883` | Port for password broker |
 | `BROKER_PASS_USER` | `testuser` | Username for password broker |
 | `BROKER_PASS_PASS` | `testpass` | Password for password broker |
 | `BROKER_TLS_HOST` | `mosquitto-tls` | Host for TLS/SSL broker |
 | `BROKER_TLS_PORT` | `8883` | Port for TLS/SSL broker |
 | `TLS_CA_CERT` | `/certs/ca.crt` | Path to CA certificate for TLS broker |
+
+---
+
+## Seeded dashboards
+
+`docker/dev/config.json` seeds three dashboards covering all 12 panel types against the topics above:
+
+- **Showcase · Monitors** — gauges (all three renderings), graphs (all three curves), stats, each group with a debug log of the exact messages it reads.
+- **Showcase · Controls** — toggles, sliders, buttons, inputs and crons, all wired to the devices above, with debug logs showing commands out and the worker's replies.
+- **Showcase · Layout** — text, separator and image, the panel types that never touch a broker.
+
+Dashboards are only seeded when one of that name has **no panels**. To pick up edits to `config.json`, delete `backend/data/mqtt-dashboard.db` and restart the stack.
 
 ---
 
@@ -49,4 +97,3 @@ export TLS_CA_CERT=../mosquitto/certs/ca.crt
 
 python worker.py
 ```
-

--- a/docker/dev/worker/worker.py
+++ b/docker/dev/worker/worker.py
@@ -1,13 +1,23 @@
 #!/usr/bin/env python3
 """
-MQTT Worker — publishes test messages to all three dev brokers.
+MQTT Worker — feeds the dev brokers so every panel type has something to show.
 
-Two publishing profiles run concurrently:
-  - IoT simulator  : random sensor data on sensors/<room>/<metric> topics
-  - Simple payloads: incrementing counters on test/<topic> topics
+Three profiles run concurrently:
+
+  - IoT simulator  : random sensor data on sensors/<room>/<metric>, all brokers
+  - Simple payloads: incrementing counters on test/<topic>, all brokers
+  - Showcase device: the demo/ namespace on the plain broker only — smooth
+                     series for the graph, and simulated devices that answer
+                     the commands the toggle, slider, button, input and cron
+                     panels publish. Without this last part those panels have
+                     nowhere to publish to and never read a state back.
+
+The showcase stays on one broker on purpose: it ticks fast, and triplicating it
+would fill the history database with the same three copies of every point.
 
 Environment variables:
-  PUBLISH_INTERVAL   seconds between publish rounds (default: 5)
+  PUBLISH_INTERVAL   seconds between sensors/ and test/ rounds (default: 5)
+  DEMO_INTERVAL      seconds between demo/ telemetry ticks (default: 1)
   BROKER_PLAIN_HOST  plain broker host (default: mosquitto)
   BROKER_PLAIN_PORT  plain broker port (default: 1883)
   BROKER_PASS_HOST   password broker host (default: mosquitto-password)
@@ -26,6 +36,7 @@ import random
 import signal
 import ssl
 import sys
+import threading
 import time
 from datetime import datetime, timezone
 
@@ -41,6 +52,7 @@ logger = logging.getLogger("mqtt-worker")
 # ── Configuration ──────────────────────────────────────────────────────────────
 
 PUBLISH_INTERVAL = float(os.environ.get("PUBLISH_INTERVAL", "5"))
+DEMO_INTERVAL = float(os.environ.get("DEMO_INTERVAL", "1"))
 
 BROKERS = [
     {
@@ -50,6 +62,8 @@ BROKERS = [
         "tls": False,
         "username": None,
         "password": None,
+        # The demo/ namespace lives here only — see the module docstring.
+        "showcase": True,
     },
     {
         "name": "password",
@@ -58,6 +72,7 @@ BROKERS = [
         "tls": False,
         "username": os.environ.get("BROKER_PASS_USER", "testuser"),
         "password": os.environ.get("BROKER_PASS_PASS", "testpass"),
+        "showcase": False,
     },
     {
         "name": "tls",
@@ -69,6 +84,7 @@ BROKERS = [
         "client_key": os.environ.get("TLS_CLIENT_KEY", "/certs/client.key"),
         "username": None,
         "password": None,
+        "showcase": False,
     },
 ]
 
@@ -103,6 +119,203 @@ SIMPLE_PAYLOADS = [
     lambda: random.choice(["online", "offline", "idle", "busy"]),
 ]
 
+# ── Showcase: the demo/ namespace ──────────────────────────────────────────────
+#
+# Telemetry is a random walk rather than an independent draw per tick: a graph
+# of uniform noise says nothing about whether the chart works, where a walk with
+# a visible trend does. Each series carries its bounds so it cannot wander off
+# the axis a panel is configured with.
+
+DEMO_SERIES = {
+    # topic: [value, low, high, step, shape]
+    "demo/graph/temperature": [21.5, 17.0, 27.0, 0.25, "json"],
+    "demo/graph/humidity": [48.0, 30.0, 70.0, 0.6, "json"],
+    # Bare number, no JSON around it — the other half of what payload shapes
+    # have to cope with, and what most small devices actually publish.
+    "demo/graph/power": [1200.0, 200.0, 2600.0, 45.0, "bare"],
+    # Mostly numbers with the occasional bit of text, so the graph's "nothing
+    # numeric in these messages" path and the log panel both have a subject.
+    "demo/graph/mixed": [50.0, 0.0, 100.0, 4.0, "flaky"],
+}
+
+DEMO_UNITS = {
+    "demo/graph/temperature": "°C",
+    "demo/graph/humidity": "%",
+    "demo/graph/power": "W",
+    "demo/graph/mixed": "",
+}
+
+# Devices the control panels drive. State is retained so a freshly loaded
+# dashboard shows the real position instead of waiting for the next command.
+DEMO_STATE = {
+    "lamp": "OFF",       # demo/lamp/state    — toggle panel
+    "fan": 40,           # demo/fan/state     — slider panel
+    "setpoint": 21.0,    # demo/thermostat/state — slider with a JSON shape
+    "measured": 21.0,
+}
+_state_lock = threading.Lock()
+
+# What the worker listens to. Every one of these is something a panel in the
+# showcase dashboards publishes; anything arriving here is echoed to
+# demo/events, which is what makes a log panel useful for debugging a control.
+COMMAND_TOPICS = [
+    "demo/lamp/set",
+    "demo/fan/set",
+    "demo/thermostat/set",
+    "demo/actions/+",
+    "test/command",
+    "test/heartbeat",
+]
+
+EVENTS_TOPIC = "demo/events"
+
+
+def _step_series(topic: str) -> str:
+    """Advance one demo series and render the payload a device would send."""
+    value, low, high, step, shape = DEMO_SERIES[topic]
+    value += random.uniform(-step, step)
+    # Reflect off the bounds rather than clamping: a series pinned flat at its
+    # limit looks like a broken feed.
+    if value < low:
+        value = low + (low - value)
+    if value > high:
+        value = high - (value - high)
+    DEMO_SERIES[topic][0] = value
+
+    rounded = round(value, 1)
+
+    if shape == "bare":
+        return str(int(rounded))
+    if shape == "flaky":
+        if random.random() < 0.12:
+            return random.choice(["n/a", "unavailable", "error"])
+        return str(rounded)
+    return json.dumps({
+        "value": rounded,
+        "unit": DEMO_UNITS[topic],
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    })
+
+
+def _publish(client: mqtt.Client, topic: str, payload: str, qos: int = 0, retain: bool = False):
+    result = client.publish(topic, payload, qos=qos, retain=retain)
+    if result.rc != mqtt.MQTT_ERR_SUCCESS:
+        logger.warning("Publish failed on %s: rc=%d", topic, result.rc)
+    return result.rc == mqtt.MQTT_ERR_SUCCESS
+
+
+def publish_demo_state(client: mqtt.Client):
+    """Publish every device state, retained. Called on connect and on change."""
+    with _state_lock:
+        lamp = DEMO_STATE["lamp"]
+        fan = DEMO_STATE["fan"]
+        setpoint = DEMO_STATE["setpoint"]
+        measured = DEMO_STATE["measured"]
+
+    # Three deliberately different shapes, so the panels reading them exercise
+    # three different read templates rather than the same one three times.
+    _publish(client, "demo/lamp/state", lamp, qos=1, retain=True)
+    _publish(client, "demo/fan/state", json.dumps({"speed": fan, "unit": "%"}), qos=1, retain=True)
+    _publish(
+        client,
+        "demo/thermostat/state",
+        json.dumps({"setpoint": round(setpoint, 1), "measured": round(measured, 1), "unit": "°C"}),
+        qos=1,
+        retain=True,
+    )
+
+
+def _as_number(text: str):
+    """The number in a payload, whether it is bare or wrapped in JSON."""
+    try:
+        return float(text)
+    except ValueError:
+        pass
+    try:
+        doc = json.loads(text)
+    except (ValueError, TypeError):
+        return None
+    if isinstance(doc, (int, float)) and not isinstance(doc, bool):
+        return float(doc)
+    if isinstance(doc, dict):
+        for key in ("value", "speed", "setpoint", "level", "position"):
+            if isinstance(doc.get(key), (int, float)) and not isinstance(doc[key], bool):
+                return float(doc[key])
+    return None
+
+
+ON_WORDS = ("ON", "TRUE", "1", "YES", "OPEN")
+OFF_WORDS = ("OFF", "FALSE", "0", "NO", "CLOSED")
+
+
+def _as_state(text: str):
+    """ON/OFF out of a payload, bare or wrapped — a toggle may publish either.
+
+    A panel writing through a shape sends `{"state": "ON"}` where a bare one
+    sends `ON`; both mean the same thing to the device, so both are accepted.
+    """
+    word = text.strip().strip('"').upper()
+    if word in ON_WORDS:
+        return "ON"
+    if word in OFF_WORDS:
+        return "OFF"
+    try:
+        doc = json.loads(text)
+    except (ValueError, TypeError):
+        return None
+    if isinstance(doc, bool):
+        return "ON" if doc else "OFF"
+    if isinstance(doc, dict):
+        for key in ("state", "value", "power", "lamp", "status"):
+            if key in doc:
+                return _as_state(str(doc[key]))
+    return None
+
+
+def handle_command(client: mqtt.Client, topic: str, payload: str) -> str:
+    """
+    Apply a command from a panel and answer with the line to log.
+
+    Returning the description rather than logging it here keeps the echo to
+    demo/events in one place, so every command shows up there exactly once —
+    including the ones that change nothing, which are the interesting case when
+    a control panel looks like it is doing nothing.
+    """
+    if topic == "demo/lamp/set":
+        state = _as_state(payload)
+        if state is None:
+            return f"lamp: unrecognised payload {payload!r}"
+        with _state_lock:
+            DEMO_STATE["lamp"] = state
+        publish_demo_state(client)
+        return f"lamp → {state}"
+
+    if topic == "demo/fan/set":
+        number = _as_number(payload)
+        if number is None:
+            return f"fan: no number in {payload!r}"
+        speed = int(max(0, min(100, number)))
+        with _state_lock:
+            DEMO_STATE["fan"] = speed
+        publish_demo_state(client)
+        return f"fan → {speed}%"
+
+    if topic == "demo/thermostat/set":
+        number = _as_number(payload)
+        if number is None:
+            return f"thermostat: no number in {payload!r}"
+        setpoint = max(5.0, min(30.0, number))
+        with _state_lock:
+            DEMO_STATE["setpoint"] = setpoint
+        publish_demo_state(client)
+        return f"thermostat → {setpoint:g}°C"
+
+    if topic.startswith("demo/actions/"):
+        return f"action {topic.rsplit('/', 1)[-1]}: {payload}"
+
+    return f"{topic}: {payload}"
+
+
 # ── MQTT client factory ────────────────────────────────────────────────────────
 
 
@@ -128,17 +341,45 @@ def make_client(broker: dict) -> mqtt.Client:
             client.tls_insecure_set(False)
 
     def on_connect(c, userdata, flags, reason_code, properties):
-        if reason_code == 0:
-            logger.info("Connected to %s broker at %s:%d", broker["name"], broker["host"], broker["port"])
-        else:
+        if reason_code != 0:
             logger.error("Failed to connect to %s broker: reason_code=%s", broker["name"], reason_code)
+            return
+        logger.info("Connected to %s broker at %s:%d", broker["name"], broker["host"], broker["port"])
+        if not broker.get("showcase"):
+            return
+        # Subscribing here rather than once after connect means a reconnect
+        # restores the subscriptions too, instead of leaving the controls dead.
+        for filt in COMMAND_TOPICS:
+            c.subscribe(filt, qos=1)
+        logger.info("Listening for panel commands on %s", ", ".join(COMMAND_TOPICS))
+        publish_demo_state(c)
 
     def on_disconnect(c, userdata, disconnect_flags, reason_code, properties):
         if reason_code != 0:
             logger.warning("Disconnected from %s broker unexpectedly: %s", broker["name"], reason_code)
 
+    def on_message(c, userdata, msg):
+        payload = msg.payload.decode("utf-8", errors="replace")
+        try:
+            description = handle_command(c, msg.topic, payload)
+        except Exception as exc:  # a bad payload must not kill the worker
+            logger.exception("Error handling %s", msg.topic)
+            description = f"{msg.topic}: error — {exc}"
+        logger.info("Command %s → %s", msg.topic, description)
+        _publish(
+            c,
+            EVENTS_TOPIC,
+            json.dumps({
+                "topic": msg.topic,
+                "payload": payload,
+                "result": description,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }),
+        )
+
     client.on_connect = on_connect
     client.on_disconnect = on_disconnect
+    client.on_message = on_message
 
     return client
 
@@ -178,6 +419,37 @@ def publish_simple(client: mqtt.Client, broker_name: str):
     return topic, str(payload)
 
 
+def publish_demo_tick(client: mqtt.Client):
+    """One tick of showcase telemetry: every series, every time.
+
+    The sensors/ simulator picks one random topic per round, which leaves any
+    single topic with a point every few minutes — far too sparse to draw a line
+    with. The showcase series are published together on every tick instead.
+    """
+    for topic in DEMO_SERIES:
+        _publish(client, topic, _step_series(topic))
+
+    # The measured temperature chases the setpoint, so moving the thermostat
+    # slider shows up as a curve on the graph rather than an instant jump.
+    with _state_lock:
+        setpoint = DEMO_STATE["setpoint"]
+        measured = DEMO_STATE["measured"]
+        measured += (setpoint - measured) * 0.08 + random.uniform(-0.05, 0.05)
+        DEMO_STATE["measured"] = measured
+        fan = DEMO_STATE["fan"]
+        lamp = DEMO_STATE["lamp"]
+
+    _publish(client, "demo/thermostat/measured", json.dumps({"value": round(measured, 2), "unit": "°C"}))
+    # A single JSON document holding everything, for panels reading one topic
+    # through different shapes — and an easy target for a debug log panel.
+    _publish(client, "demo/house/summary", json.dumps({
+        "lamp": lamp,
+        "fan": {"speed": fan, "unit": "%"},
+        "thermostat": {"setpoint": round(setpoint, 1), "measured": round(measured, 1)},
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }))
+
+
 def _unit_for(template: str) -> str:
     if "temperature" in template:
         return "°C"
@@ -206,8 +478,8 @@ signal.signal(signal.SIGINT, _shutdown)
 
 
 def main():
-    logger.info("MQTT Worker starting — interval=%.1fs, brokers=%s",
-                PUBLISH_INTERVAL, [b["name"] for b in BROKERS])
+    logger.info("MQTT Worker starting — interval=%.1fs, demo interval=%.1fs, brokers=%s",
+                PUBLISH_INTERVAL, DEMO_INTERVAL, [b["name"] for b in BROKERS])
 
     clients = []
     for broker in BROKERS:
@@ -222,37 +494,48 @@ def main():
         logger.error("No brokers connected — exiting")
         sys.exit(1)
 
+    # The two profiles run at different rates, so the slow one is driven by
+    # elapsed time rather than by counting fast ticks.
     round_num = 0
+    next_slow_round = 0.0
+
     while _running:
-        round_num += 1
+        now = time.monotonic()
+
         for client, broker in clients:
             if not client.is_connected():
-                logger.warning("Broker %s disconnected — skipping round %d", broker["name"], round_num)
                 continue
+            if broker.get("showcase"):
+                publish_demo_tick(client)
 
-            # IoT payload
-            topic, payload = publish_iot(client, broker["name"])
-            qos = random.choice([0, 1, 2])
-            retain = random.random() < 0.2  # 20% chance of retain
-            result = client.publish(topic, payload, qos=qos, retain=retain)
-            if result.rc == mqtt.MQTT_ERR_SUCCESS:
-                logger.debug("[%s] IoT → %s (qos=%d retain=%s): %s", broker["name"], topic, qos, retain, payload)
-            else:
-                logger.warning("[%s] Publish failed on %s: rc=%d", broker["name"], topic, result.rc)
+        if now >= next_slow_round:
+            round_num += 1
+            published_to = 0
+            for client, broker in clients:
+                if not client.is_connected():
+                    logger.warning("Broker %s disconnected — skipping round %d", broker["name"], round_num)
+                    continue
+                published_to += 1
 
-            # Simple payload
-            topic, payload = publish_simple(client, broker["name"])
-            qos = random.choice([0, 1, 2])
-            retain = random.random() < 0.2
-            result = client.publish(topic, payload, qos=qos, retain=retain)
-            if result.rc == mqtt.MQTT_ERR_SUCCESS:
-                logger.debug("[%s] Simple → %s (qos=%d retain=%s): %s", broker["name"], topic, qos, retain, payload)
-            else:
-                logger.warning("[%s] Publish failed on %s: rc=%d", broker["name"], topic, result.rc)
+                # IoT payload
+                topic, payload = publish_iot(client, broker["name"])
+                qos = random.choice([0, 1, 2])
+                retain = random.random() < 0.2  # 20% chance of retain
+                if _publish(client, topic, payload, qos=qos, retain=retain):
+                    logger.debug("[%s] IoT → %s (qos=%d retain=%s): %s", broker["name"], topic, qos, retain, payload)
 
-        logger.info("Round %d done — published to %d broker(s) — next in %.1fs",
-                    round_num, len(clients), PUBLISH_INTERVAL)
-        time.sleep(PUBLISH_INTERVAL)
+                # Simple payload
+                topic, payload = publish_simple(client, broker["name"])
+                qos = random.choice([0, 1, 2])
+                retain = random.random() < 0.2
+                if _publish(client, topic, payload, qos=qos, retain=retain):
+                    logger.debug("[%s] Simple → %s (qos=%d retain=%s): %s", broker["name"], topic, qos, retain, payload)
+
+            logger.info("Round %d done — published to %d broker(s) — next in %.1fs",
+                        round_num, published_to, PUBLISH_INTERVAL)
+            next_slow_round = now + PUBLISH_INTERVAL
+
+        time.sleep(DEMO_INTERVAL)
 
     for client, broker in clients:
         client.loop_stop()

--- a/frontend/src/components/explorer/ExplorerPublishPanel.tsx
+++ b/frontend/src/components/explorer/ExplorerPublishPanel.tsx
@@ -6,6 +6,13 @@ import {
 import InputPanel from "../panels/InputPanel";
 import { PublishOptionsCard } from "../panels/config";
 
+/**
+ * Once someone has read why a wildcard topic cannot be published to, they know
+ * it for every wildcard topic — so the dismissal is remembered across sessions
+ * and topics rather than reappearing on each new `+`/`#` selection.
+ */
+const WILDCARD_NOTICE_KEY = "mqtt_wildcard_publish_notice_dismissed";
+
 interface Props {
   brokerId: string;
   selectedTopic: string;
@@ -17,13 +24,19 @@ export default function ExplorerPublishPanel({
 }: Props) {
   const [qos, setQos] = useState(0);
   const [retain, setRetain] = useState(false);
-  const [dismissedTopic, setDismissedTopic] = useState<string | null>(null);
+  const [noticeDismissed, setNoticeDismissed] = useState(
+    () => localStorage.getItem(WILDCARD_NOTICE_KEY) === "true",
+  );
 
   const isWildcard = selectedTopic.includes("+") || selectedTopic.includes("#");
-  const isDismissed = dismissedTopic === selectedTopic;
+
+  const dismissNotice = () => {
+    localStorage.setItem(WILDCARD_NOTICE_KEY, "true");
+    setNoticeDismissed(true);
+  };
 
   if (isWildcard) {
-    if (isDismissed) return null;
+    if (noticeDismissed) return null;
     return (
       <div className="border border-base-300 bg-base-200/40 rounded-xl p-3 text-xs flex flex-col gap-1 relative">
         <div className="flex items-center justify-between font-semibold text-base-content">
@@ -35,7 +48,7 @@ export default function ExplorerPublishPanel({
             type="button"
             className="btn btn-xs btn-ghost btn-square text-base-content/60 hover:text-base-content shrink-0"
             title="Dismiss warning"
-            onClick={() => setDismissedTopic(selectedTopic)}
+            onClick={dismissNotice}
           >
             <CloseIcon className="text-sm" />
           </button>

--- a/frontend/src/components/panels/GraphPanel.tsx
+++ b/frontend/src/components/panels/GraphPanel.tsx
@@ -1,0 +1,904 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { MdShowChart } from "react-icons/md";
+import { useWebSocket } from "../../hooks/useWebSocket";
+import { api } from "../../api/client";
+import { usePanelSize } from "../../hooks/usePanelSize";
+import { usePayloadSample } from "../../hooks/usePayloadSample";
+import type { BrokerStatus } from "../../hooks/useBrokers";
+import {
+  BrokerTopicCard,
+  ChoiceCards,
+  ConfigCard,
+  ConfigGroup,
+  DisclosureCard,
+  FieldRow,
+  NumberRangeRow,
+  PanelConfigModal,
+  PayloadBuilder,
+  PayloadSummary,
+  SwitchRow,
+  brokerPresence,
+  brokerRules,
+  defaultBrokerId,
+  payloadRules,
+  topicRules,
+  useConfigValidation,
+} from "./config";
+import { VALUE_TOKEN, readShape, templateFromValueKey } from "./payloadShape";
+import {
+  appendPoint,
+  autoNumericPayload,
+  buildAreaPath,
+  buildLinePath,
+  computeBounds,
+  formatTimeLabel,
+  formatValue,
+  graphReadTemplate,
+  nearestPoint,
+  parseNumericPayload,
+  projectX,
+  projectY,
+  seriesColor,
+  trimSeries,
+  valueTicks,
+  type CurveType,
+  type GraphSeries,
+} from "./graphUtils";
+
+export interface GraphConfig {
+  topics?: string;
+  /** Shape of incoming messages, with `{value}` marking the part to plot. */
+  readTemplate?: string;
+  /** Legacy dot path, kept so panels saved before shapes existed still read. */
+  valueKey?: string;
+  unit?: string;
+  maxPoints?: number;
+  timeWindowSeconds?: number;
+  yMin?: number | null;
+  yMax?: number | null;
+  curve?: CurveType;
+  showArea?: boolean;
+  showPoints?: boolean;
+  showLegend?: boolean;
+}
+
+export const DEFAULT_MAX_POINTS = 200;
+export const DEFAULT_WINDOW_SECONDS = 900;
+/** A wildcard can match hundreds of topics; past this the chart is unreadable. */
+const MAX_SERIES = 12;
+
+const TIME_WINDOWS: { value: number; label: string }[] = [
+  { value: 60, label: "Last minute" },
+  { value: 300, label: "Last 5 minutes" },
+  { value: 900, label: "Last 15 minutes" },
+  { value: 3600, label: "Last hour" },
+  { value: 21600, label: "Last 6 hours" },
+  { value: 86400, label: "Last 24 hours" },
+  { value: 0, label: "All stored history" },
+];
+
+interface ModalProps {
+  config: GraphConfig;
+  brokerId: string;
+  brokerStatuses: BrokerStatus[];
+  onSave: (cfg: GraphConfig, brokerId: string) => void;
+  onClose: () => void;
+  onPickTopic?: (data: {
+    currentTopic: string;
+    selectedBrokerId: string;
+    draftConfig?: GraphConfig;
+  }) => void;
+  initialTopic?: string;
+  initialBrokerId?: string;
+}
+
+export function GraphConfigModal({
+  config,
+  brokerId,
+  brokerStatuses,
+  onSave,
+  onClose,
+  onPickTopic,
+  initialTopic,
+  initialBrokerId,
+}: ModalProps) {
+  const fallbackBroker = defaultBrokerId(brokerStatuses);
+  const [topics, setTopics] = useState(initialTopic ?? config.topics ?? "");
+  const [readTemplate, setReadTemplate] = useState(graphReadTemplate(config));
+  const [unit, setUnit] = useState(config.unit ?? "");
+  const [maxPoints, setMaxPoints] = useState(
+    String(config.maxPoints ?? DEFAULT_MAX_POINTS),
+  );
+  const [timeWindowSeconds, setTimeWindowSeconds] = useState(
+    config.timeWindowSeconds ?? DEFAULT_WINDOW_SECONDS,
+  );
+  const [yMin, setYMin] = useState(
+    config.yMin === null || config.yMin === undefined
+      ? ""
+      : String(config.yMin),
+  );
+  const [yMax, setYMax] = useState(
+    config.yMax === null || config.yMax === undefined
+      ? ""
+      : String(config.yMax),
+  );
+  const [curve, setCurve] = useState<CurveType>(config.curve ?? "linear");
+  const [showArea, setShowArea] = useState(config.showArea ?? true);
+  const [showPoints, setShowPoints] = useState(config.showPoints ?? false);
+  const [showLegend, setShowLegend] = useState(config.showLegend ?? true);
+  const [selectedBrokerId, setSelectedBrokerId] = useState(
+    initialBrokerId || brokerId || fallbackBroker,
+  );
+
+  const { recent, loading } = usePayloadSample(selectedBrokerId, topics);
+  const latest = recent[0]?.payload ?? null;
+
+  // A stored dot path no shape can draw — an array index — is only held by this
+  // field, so it is carried through saves and topic-picker round trips.
+  const legacyPath =
+    readTemplate.trim() === VALUE_TOKEN &&
+    !templateFromValueKey(config.valueKey)
+      ? config.valueKey
+      : undefined;
+
+  const reading = latest ? readShape(readTemplate, latest, legacyPath) : null;
+  // "Nothing published yet" and "the shape does not fit" are different
+  // problems; only a shape that resolved can say the payload is not a number.
+  const nonNumeric =
+    (reading?.found ?? false) &&
+    reading?.dataType !== "number" &&
+    reading?.dataType !== "boolean";
+
+  const pointsNum = Number(maxPoints);
+  const yMinNum = yMin.trim() === "" ? null : Number(yMin);
+  const yMaxNum = yMax.trim() === "" ? null : Number(yMax);
+
+  const { fieldErrors, blockerReason } = useConfigValidation([
+    ...brokerRules(brokerStatuses.length),
+    ...topicRules({ field: "topic", topic: topics, allowWildcards: true }),
+    // Blank reads the whole payload, which is right for a device publishing a
+    // bare number; bytes with nothing marked in them are a shape the panel
+    // cannot use.
+    ...payloadRules({
+      field: "readShape",
+      value: readTemplate,
+      mode: "read",
+      allowEmpty: true,
+    }),
+    {
+      field: "points",
+      when: !Number.isFinite(pointsNum) || pointsNum < 2 || pointsNum > 2000,
+      message: "Points must be a number between 2 and 2000.",
+    },
+    {
+      field: "scale",
+      when:
+        (yMin.trim() !== "" && !Number.isFinite(yMinNum as number)) ||
+        (yMax.trim() !== "" && !Number.isFinite(yMaxNum as number)),
+      message: "Min and Max must be numbers, or left blank to fit the data.",
+    },
+    {
+      field: "scale",
+      when:
+        yMinNum !== null &&
+        yMaxNum !== null &&
+        Number.isFinite(yMinNum) &&
+        Number.isFinite(yMaxNum) &&
+        yMaxNum <= yMinNum,
+      message: "Max must be greater than Min.",
+    },
+  ]);
+
+  const draft = (): GraphConfig => ({
+    topics,
+    readTemplate,
+    valueKey: legacyPath,
+    unit,
+    // A half-typed box comes back as it was left, not as the text `NaN` for
+    // the user to clear again.
+    maxPoints: Number.isFinite(pointsNum) ? pointsNum : config.maxPoints,
+    timeWindowSeconds,
+    yMin: yMinNum !== null && Number.isFinite(yMinNum) ? yMinNum : null,
+    yMax: yMaxNum !== null && Number.isFinite(yMaxNum) ? yMaxNum : null,
+    curve,
+    showArea,
+    showPoints,
+    showLegend,
+  });
+
+  return (
+    <PanelConfigModal
+      icon={MdShowChart}
+      title="Graph Configuration"
+      brokerStatus={brokerPresence(brokerStatuses, selectedBrokerId)}
+      blockerReason={blockerReason}
+      onCancel={onClose}
+      onSave={() => onSave(draft(), selectedBrokerId || fallbackBroker)}
+    >
+      <ConfigGroup heading="Read">
+        <BrokerTopicCard
+          title="Reads from"
+          brokers={brokerStatuses}
+          brokerId={selectedBrokerId}
+          onBrokerChange={setSelectedBrokerId}
+          topic={topics}
+          onTopicChange={(next) => {
+            setTopics(next);
+          }}
+          topicPlaceholder="sensors/+/temp, home/attic/humidity"
+          topicError={fieldErrors.topic}
+          help={`Every matching topic gets its own line, up to ${MAX_SERIES}. Read-only, so wildcards (+ and #) are fine.`}
+          onExplore={
+            onPickTopic
+              ? () =>
+                  onPickTopic({
+                    currentTopic: "",
+                    selectedBrokerId,
+                    draftConfig: draft(),
+                  })
+              : undefined
+          }
+        />
+
+        <DisclosureCard
+          title="Value"
+          summary={
+            <PayloadSummary value={readTemplate} empty="whole payload" />
+          }
+          defaultOpen={Boolean(fieldErrors.readShape)}
+          invalid={Boolean(fieldErrors.readShape)}
+        >
+          <PayloadBuilder
+            mode="read"
+            value={readTemplate}
+            onChange={(next) => {
+              setReadTemplate(next);
+            }}
+            history={{ messages: recent, loading }}
+            brokerId={selectedBrokerId}
+            topic={topics}
+            allowBlankShape
+            readPath={legacyPath}
+            unit={unit}
+            placeholder={`whole payload, or {"temp":${VALUE_TOKEN}}`}
+          />
+          {fieldErrors.readShape && (
+            <span className="text-[11px] text-warning">
+              {fieldErrors.readShape}
+            </span>
+          )}
+          {nonNumeric && (
+            <span className="text-[11px] leading-relaxed text-warning">
+              The value this shape reads is text, and only numbers can be
+              plotted. Booleans are drawn as 1 and 0; anything else is skipped.
+            </span>
+          )}
+        </DisclosureCard>
+      </ConfigGroup>
+
+      <ConfigGroup heading="Appearance">
+        <ConfigCard title="Line style" summary="How points are joined up">
+          <ChoiceCards<CurveType>
+            value={curve}
+            onChange={setCurve}
+            options={[
+              {
+                id: "linear",
+                label: "Straight",
+                preview: <CurvePreview curve="linear" />,
+              },
+              {
+                id: "smooth",
+                label: "Smooth",
+                preview: <CurvePreview curve="smooth" />,
+              },
+              {
+                id: "step",
+                label: "Step",
+                preview: <CurvePreview curve="step" />,
+              },
+            ]}
+          />
+          <SwitchRow
+            name="Fill under the line"
+            note="Tints the area down to the baseline"
+            on={showArea}
+            onToggle={setShowArea}
+          />
+          <SwitchRow
+            name="Dot per message"
+            note="Marks where each message landed"
+            on={showPoints}
+            onToggle={setShowPoints}
+          />
+          <SwitchRow
+            name="Legend"
+            note="Names each line and its latest value"
+            on={showLegend}
+            onToggle={setShowLegend}
+          />
+        </ConfigCard>
+
+        <ConfigCard
+          title="Window"
+          summary="How much of the past is drawn"
+          invalid={Boolean(fieldErrors.points)}
+        >
+          <FieldRow label="Range">
+            <select
+              className="select select-bordered w-full min-w-0 h-8 min-h-8 text-xs"
+              value={timeWindowSeconds}
+              onChange={(e) => setTimeWindowSeconds(Number(e.target.value))}
+            >
+              {TIME_WINDOWS.map((w) => (
+                <option key={w.value} value={w.value}>
+                  {w.label}
+                </option>
+              ))}
+            </select>
+          </FieldRow>
+          <FieldRow
+            label="Points"
+            invalid={Boolean(fieldErrors.points)}
+            help={
+              fieldErrors.points ??
+              "How many points each line keeps before dropping the oldest."
+            }
+          >
+            <input
+              className={`input input-bordered w-full min-w-0 h-8 min-h-8 font-mono text-xs ${
+                fieldErrors.points ? "input-warning" : ""
+              }`}
+              inputMode="numeric"
+              value={maxPoints}
+              onChange={(e) => {
+                setMaxPoints(e.target.value);
+              }}
+            />
+          </FieldRow>
+        </ConfigCard>
+
+        <ConfigCard
+          title="Scale"
+          summary="Blank fits the data"
+          invalid={Boolean(fieldErrors.scale)}
+        >
+          <NumberRangeRow
+            fields={[
+              {
+                label: "Min",
+                value: yMin,
+                placeholder: "auto",
+                invalid: Boolean(fieldErrors.scale),
+                onChange: (next) => {
+                  setYMin(next);
+                },
+              },
+              {
+                label: "Max",
+                value: yMax,
+                placeholder: "auto",
+                invalid: Boolean(fieldErrors.scale),
+                onChange: (next) => {
+                  setYMax(next);
+                },
+              },
+            ]}
+          />
+          {fieldErrors.scale && (
+            <span className="text-[11px] text-warning">
+              {fieldErrors.scale}
+            </span>
+          )}
+          <FieldRow label="Unit" help="Shown next to values in the legend.">
+            <input
+              className="input input-bordered w-full min-w-0 h-8 min-h-8 text-xs"
+              placeholder="°C, %, kW"
+              value={unit}
+              onChange={(e) => setUnit(e.target.value)}
+            />
+          </FieldRow>
+        </ConfigCard>
+      </ConfigGroup>
+    </PanelConfigModal>
+  );
+}
+
+/** The three joins, drawn over the same points so the choice is the preview. */
+function CurvePreview({ curve }: { curve: CurveType }) {
+  const points = [
+    { t: 0, v: 6 },
+    { t: 1, v: 22 },
+    { t: 2, v: 14 },
+    { t: 3, v: 30 },
+    { t: 4, v: 24 },
+  ];
+  const bounds = { minT: 0, maxT: 4, minV: 0, maxV: 34 };
+
+  return (
+    <svg viewBox="0 0 60 34" className="w-full h-full text-primary">
+      <path
+        d={buildLinePath(points, bounds, 60, 34, curve)}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+interface GraphPanelProps {
+  panelId: string;
+  brokerId: string;
+  config: GraphConfig;
+  /** Hides the Clear / Pause toolbar, for the explorer's compact view. */
+  compact?: boolean;
+  /**
+   * Plot the first numeric field found in each payload instead of the panel's
+   * configured shape. For the explorer, which charts whatever topic is clicked
+   * and has nowhere to configure one.
+   */
+  autoValue?: boolean;
+}
+
+/** Room for the value axis on the left and the time labels underneath. */
+const PADDING = { top: 8, right: 8, bottom: 18, left: 40 };
+
+export default function GraphPanel({
+  panelId,
+  brokerId,
+  config,
+  compact = false,
+  autoValue = false,
+}: GraphPanelProps) {
+  const [series, setSeries] = useState<GraphSeries[]>([]);
+  // Messages are arriving but nothing plottable comes out of them — a different
+  // problem from a topic that has simply been quiet, and the only one the user
+  // can fix, so the two are never reported as one.
+  const [nonNumericSeen, setNonNumericSeen] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const [hoverX, setHoverX] = useState<number | null>(null);
+  const { ref: plotRef, size } = usePanelSize<HTMLDivElement>();
+  const pausedRef = useRef(paused);
+
+  const topicsKey = config.topics ?? "";
+  const readTemplate = graphReadTemplate(config);
+  const shape = useMemo(
+    () => ({ template: readTemplate, path: config.valueKey }),
+    [readTemplate, config.valueKey],
+  );
+  const readPoint = useMemo(
+    () =>
+      autoValue
+        ? (payload: string) => autoNumericPayload(payload)
+        : (payload: string) => parseNumericPayload(payload, shape),
+    [autoValue, shape],
+  );
+  const unit = config.unit ?? "";
+  const maxPoints = config.maxPoints ?? DEFAULT_MAX_POINTS;
+  const windowMs = (config.timeWindowSeconds ?? DEFAULT_WINDOW_SECONDS) * 1000;
+  const curve = config.curve ?? "linear";
+  const showArea = config.showArea ?? true;
+  const showPoints = config.showPoints ?? false;
+  const showLegend = config.showLegend ?? true;
+  const yMin = config.yMin ?? undefined;
+  const yMax = config.yMax ?? undefined;
+
+  const topicList = useMemo(
+    () =>
+      topicsKey
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean),
+    [topicsKey],
+  );
+
+  useEffect(() => {
+    pausedRef.current = paused;
+  }, [paused]);
+
+  // Drop buffered points when the source changes, so lines never mix topics.
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setSeries([]);
+      setNonNumericSeen(false);
+    }, 0);
+    return () => clearTimeout(id);
+  }, [brokerId, topicsKey, readPoint]);
+
+  // Seed from stored history so a panel opens with its past already drawn.
+  useEffect(() => {
+    if (!brokerId || topicList.length === 0) return;
+    let cancelled = false;
+
+    Promise.all(
+      topicList.map((topic) =>
+        api.getExplorerHistory(brokerId, topic).catch((error) => {
+          void error;
+          return [];
+        }),
+      ),
+    ).then((results) => {
+      if (cancelled) return;
+      const now = Date.now();
+      const options = { maxPoints, windowMs, now, maxSeries: MAX_SERIES };
+      let seeded: GraphSeries[] = [];
+      const records = results
+        .flat()
+        .sort(
+          (a, b) =>
+            new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+        );
+      for (const record of records) {
+        const value = readPoint(record.payload);
+        if (value === null) continue;
+        const t = new Date(record.timestamp).getTime();
+        if (Number.isNaN(t)) continue;
+        seeded = appendPoint(seeded, record.topic, { t, v: value }, options);
+      }
+      if (records.length > 0 && seeded.length === 0) {
+        setNonNumericSeen(true);
+      }
+      // Fold in live points that arrived while history was in flight, rather
+      // than replacing them and losing the newest readings.
+      setSeries((prev) => {
+        if (prev.length === 0) return seeded;
+        let merged = seeded;
+        for (const live of prev) {
+          for (const point of live.points) {
+            merged = appendPoint(merged, live.topic, point, options);
+          }
+        }
+        return merged;
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [brokerId, topicList, readPoint, maxPoints, windowMs]);
+
+  const { subscribe } = useWebSocket({
+    onMessage: (raw) => {
+      if (pausedRef.current) return;
+      try {
+        const msg = JSON.parse(raw) as {
+          topic: string;
+          payload: string;
+          timestamp?: string;
+        };
+        if (!msg.topic) return;
+        const value = readPoint(msg.payload);
+        if (value === null) {
+          setNonNumericSeen(true);
+          return;
+        }
+        const stamped = msg.timestamp ? new Date(msg.timestamp).getTime() : NaN;
+        const t = Number.isNaN(stamped) ? Date.now() : stamped;
+        setSeries((prev) =>
+          appendPoint(
+            prev,
+            msg.topic,
+            { t, v: value },
+            {
+              maxPoints,
+              windowMs,
+              now: Date.now(),
+              maxSeries: MAX_SERIES,
+            },
+          ),
+        );
+      } catch (error) {
+        void error;
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (topicList.length === 0) return;
+    subscribe({ panel_id: panelId, broker_id: brokerId, topics: topicList });
+  }, [panelId, brokerId, topicList, subscribe]);
+
+  // Expire points that scrolled out of the window even while nothing arrives,
+  // so a silent topic drains instead of freezing on its last reading.
+  useEffect(() => {
+    if (windowMs <= 0) return;
+    const interval = setInterval(() => {
+      setSeries((prev) => {
+        const next = trimSeries(prev, { maxPoints, windowMs });
+        const unchanged =
+          next.length === prev.length &&
+          next.every((s, i) => s.points.length === prev[i].points.length);
+        return unchanged ? prev : next;
+      });
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [windowMs, maxPoints]);
+
+  const bounds = useMemo(
+    () => computeBounds(series, yMin, yMax),
+    [series, yMin, yMax],
+  );
+
+  // One tinted area reads as the shape of the value; five stacked on top of
+  // each other read as mud, so the fill is for a single line only.
+  const fillArea = showArea && series.length === 1;
+
+  const plotWidth = Math.max(0, size.width - PADDING.left - PADDING.right);
+  const plotHeight = Math.max(0, size.height - PADDING.top - PADDING.bottom);
+  const totalPoints = series.reduce((sum, s) => sum + s.points.length, 0);
+
+  const hoverInfo = useMemo(() => {
+    if (hoverX === null || !bounds || plotWidth <= 0) return null;
+    const ratio = Math.min(Math.max(hoverX / plotWidth, 0), 1);
+    const t = bounds.minT + (bounds.maxT - bounds.minT) * ratio;
+    const entries = series
+      .map((s, index) => ({
+        topic: s.topic,
+        index,
+        point: nearestPoint(s.points, t),
+      }))
+      .filter(
+        (
+          entry,
+        ): entry is {
+          topic: string;
+          index: number;
+          point: { t: number; v: number };
+        } => entry.point !== null,
+      );
+    if (entries.length === 0) return null;
+    return { t, entries };
+  }, [hoverX, bounds, plotWidth, series]);
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      {!compact && (
+        <div className="flex gap-2 px-1 pb-1 shrink-0">
+          <button className="btn btn-xs" onClick={() => setSeries([])}>
+            Clear
+          </button>
+          <button
+            className={`btn btn-xs ${paused ? "btn-warning" : ""}`}
+            onClick={() => setPaused((p) => !p)}
+          >
+            {paused ? "Resume" : "Pause"}
+          </button>
+          <span className="text-xs text-base-content/50 ml-auto self-center">
+            {totalPoints} pts
+          </span>
+        </div>
+      )}
+
+      <div
+        ref={plotRef}
+        className="relative flex-1 min-h-0 w-full overflow-hidden"
+        onMouseMove={(e) => {
+          const rect = e.currentTarget.getBoundingClientRect();
+          setHoverX(e.clientX - rect.left - PADDING.left);
+        }}
+        onMouseLeave={() => setHoverX(null)}
+      >
+        {!bounds || plotWidth <= 0 || plotHeight <= 0 ? (
+          <div className="flex flex-col items-center justify-center h-full gap-2 p-4 text-center">
+            {nonNumericSeen ? (
+              <>
+                <MdShowChart className="text-3xl text-base-content/30" />
+                <span className="text-xs text-base-content/60 leading-relaxed max-w-xs">
+                  Messages are arriving on{" "}
+                  <span className="font-mono text-accent">{topicsKey}</span>,
+                  but the value read out of them is not a number. Point the
+                  value shape at the numeric field in this panel's settings.
+                </span>
+              </>
+            ) : (
+              <>
+                <div className="loading loading-spinner loading-md text-primary" />
+                <span className="text-xs text-base-content/60 font-mono animate-pulse">
+                  Waiting for numeric data on{" "}
+                  <span className="font-semibold text-accent">{topicsKey}</span>
+                  …
+                </span>
+              </>
+            )}
+          </div>
+        ) : (
+          <svg
+            width={size.width}
+            height={size.height}
+            className="block"
+            role="img"
+            aria-label={`Graph of ${topicsKey}`}
+          >
+            <g transform={`translate(${PADDING.left}, ${PADDING.top})`}>
+              {valueTicks(bounds).map((tick) => {
+                const y = projectY(tick, bounds, plotHeight);
+                return (
+                  <g key={tick}>
+                    <line
+                      x1={0}
+                      x2={plotWidth}
+                      y1={y}
+                      y2={y}
+                      stroke="currentColor"
+                      strokeWidth={1}
+                      className="text-base-content/10"
+                    />
+                    <text
+                      x={-6}
+                      y={y}
+                      textAnchor="end"
+                      dominantBaseline="middle"
+                      className="fill-base-content/50 font-mono"
+                      style={{ fontSize: "9px" }}
+                    >
+                      {formatValue(tick)}
+                    </text>
+                  </g>
+                );
+              })}
+
+              {[0, 0.5, 1].map((ratio) => {
+                const t = bounds.minT + (bounds.maxT - bounds.minT) * ratio;
+                return (
+                  <text
+                    key={ratio}
+                    x={plotWidth * ratio}
+                    y={plotHeight + 12}
+                    textAnchor={
+                      ratio === 0 ? "start" : ratio === 1 ? "end" : "middle"
+                    }
+                    className="fill-base-content/50 font-mono"
+                    style={{ fontSize: "9px" }}
+                  >
+                    {formatTimeLabel(t)}
+                  </text>
+                );
+              })}
+
+              {series.map((s, index) => {
+                const color = seriesColor(index);
+                const linePath = buildLinePath(
+                  s.points,
+                  bounds,
+                  plotWidth,
+                  plotHeight,
+                  curve,
+                );
+                return (
+                  <g key={s.topic} className={color.stroke}>
+                    {fillArea && (
+                      <path
+                        d={buildAreaPath(
+                          linePath,
+                          s.points,
+                          bounds,
+                          plotWidth,
+                          plotHeight,
+                        )}
+                        fill="currentColor"
+                        className="opacity-10"
+                        stroke="none"
+                      />
+                    )}
+                    <path
+                      d={linePath}
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={1.75}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    {showPoints &&
+                      s.points.map((p) => (
+                        <circle
+                          key={`${p.t}-${p.v}`}
+                          cx={projectX(p.t, bounds, plotWidth)}
+                          cy={projectY(p.v, bounds, plotHeight)}
+                          r={2}
+                          fill="currentColor"
+                        />
+                      ))}
+                  </g>
+                );
+              })}
+
+              {hoverInfo && (
+                <g>
+                  <line
+                    x1={projectX(hoverInfo.t, bounds, plotWidth)}
+                    x2={projectX(hoverInfo.t, bounds, plotWidth)}
+                    y1={0}
+                    y2={plotHeight}
+                    stroke="currentColor"
+                    strokeWidth={1}
+                    strokeDasharray="3 3"
+                    className="text-base-content/30"
+                  />
+                  {hoverInfo.entries.map((entry) => (
+                    <circle
+                      key={entry.topic}
+                      cx={projectX(entry.point.t, bounds, plotWidth)}
+                      cy={projectY(entry.point.v, bounds, plotHeight)}
+                      r={3.5}
+                      fill="currentColor"
+                      className={seriesColor(entry.index).stroke}
+                    />
+                  ))}
+                </g>
+              )}
+            </g>
+          </svg>
+        )}
+
+        {hoverInfo && bounds && (
+          <div
+            className="pointer-events-none absolute top-1 z-10 rounded-md border border-base-300 bg-base-100/95 px-2 py-1 shadow-lg text-[10px] font-mono max-w-[70%]"
+            style={{
+              left: Math.min(
+                Math.max(
+                  PADDING.left + projectX(hoverInfo.t, bounds, plotWidth) + 8,
+                  4,
+                ),
+                Math.max(4, size.width - 140),
+              ),
+            }}
+          >
+            <div className="text-base-content/50">
+              {formatTimeLabel(hoverInfo.t)}
+            </div>
+            {hoverInfo.entries.map((entry) => (
+              <div key={entry.topic} className="flex items-center gap-1.5">
+                <span
+                  className={`inline-block w-1.5 h-1.5 rounded-full shrink-0 ${seriesColor(entry.index).swatch}`}
+                />
+                {series.length > 1 && (
+                  <span className="truncate max-w-[110px] text-base-content/60">
+                    {entry.topic}
+                  </span>
+                )}
+                <span className="font-semibold text-base-content ml-auto">
+                  {formatValue(entry.point.v)}
+                  {unit && (
+                    <span className="text-base-content/60"> {unit}</span>
+                  )}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {showLegend && series.length > 0 && (
+        <div className="flex flex-wrap gap-x-3 gap-y-1 pt-1 shrink-0 text-[10px] text-base-content/60">
+          {series.length >= MAX_SERIES && (
+            <span className="text-warning shrink-0">
+              first {MAX_SERIES} topics
+            </span>
+          )}
+          {series.map((s, index) => {
+            const last = s.points[s.points.length - 1];
+            return (
+              <div key={s.topic} className="flex items-center gap-1 min-w-0">
+                <span
+                  className={`inline-block w-2 h-2 rounded-full shrink-0 ${seriesColor(index).swatch}`}
+                />
+                <span className="truncate max-w-[140px] font-mono">
+                  {s.topic}
+                </span>
+                {last && (
+                  <span className="font-semibold text-base-content shrink-0">
+                    {formatValue(last.v)}
+                    {unit ? ` ${unit}` : ""}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/panels/definitions.tsx
+++ b/frontend/src/components/panels/definitions.tsx
@@ -10,11 +10,13 @@ import {
   MdImage,
   MdToggleOn,
   MdTune,
+  MdShowChart,
 } from "react-icons/md";
 import { api } from "../../api/client";
 import type { PanelDefinition, ValidationResult } from "./types";
 import GaugePanel, { GaugeConfigModal, type GaugeConfig } from "./GaugePanel";
 import LogPanel, { LogConfigModal, type LogConfig } from "./LogPanel";
+import GraphPanel, { GraphConfigModal, type GraphConfig } from "./GraphPanel";
 import BrokerStatsPanel, {
   BrokerStatsConfigModal,
   type BrokerStatsConfig,
@@ -162,6 +164,41 @@ export const logPanelDefinition: PanelDefinition<LogConfig> = {
   Component: LogPanel,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConfigModal: LogConfigModal as any,
+};
+
+export const graphPanelDefinition: PanelDefinition<GraphConfig> = {
+  type: "graph",
+  label: "Graph",
+  category: "monitor",
+  icon: MdShowChart,
+  description: "Numeric payloads plotted over time",
+  preview: (
+    <div className="flex flex-col justify-center h-full gap-1 p-2">
+      <svg viewBox="0 0 100 40" className="w-full">
+        <path
+          d="M0,34 L20,24 L40,28 L60,12 L80,18 L100,6 L100,40 L0,40 Z"
+          className="text-primary"
+          fill="currentColor"
+          fillOpacity="0.15"
+          stroke="none"
+        />
+        <polyline
+          points="0,34 20,24 40,28 60,12 80,18 100,6"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          className="text-primary"
+        />
+      </svg>
+      <span className="text-[10px] text-base-content/50 font-mono text-center">
+        sensor/temp
+      </span>
+    </div>
+  ),
+  Component: GraphPanel,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ConfigModal: GraphConfigModal as any,
 };
 
 export const brokerStatsPanelDefinition: PanelDefinition<BrokerStatsConfig> = {

--- a/frontend/src/components/panels/graphUtils.ts
+++ b/frontend/src/components/panels/graphUtils.ts
@@ -1,0 +1,372 @@
+import {
+  VALUE_TOKEN,
+  extractValue,
+  readValue,
+  suggestPaths,
+  templateFromValueKey,
+} from "./payloadShape";
+
+export interface GraphPoint {
+  t: number;
+  v: number;
+}
+
+export interface GraphSeries {
+  topic: string;
+  points: GraphPoint[];
+}
+
+export interface GraphBounds {
+  minT: number;
+  maxT: number;
+  minV: number;
+  maxV: number;
+}
+
+export type CurveType = "linear" | "step" | "smooth";
+
+/** Tailwind/daisyUI class pairs used to colour each series consistently. */
+export const SERIES_COLORS = [
+  { stroke: "text-primary", swatch: "bg-primary" },
+  { stroke: "text-secondary", swatch: "bg-secondary" },
+  { stroke: "text-accent", swatch: "bg-accent" },
+  { stroke: "text-info", swatch: "bg-info" },
+  { stroke: "text-success", swatch: "bg-success" },
+  { stroke: "text-warning", swatch: "bg-warning" },
+  { stroke: "text-error", swatch: "bg-error" },
+];
+
+export function seriesColor(index: number) {
+  return SERIES_COLORS[index % SERIES_COLORS.length];
+}
+
+export interface GraphShape {
+  /** The read shape, with `{value}` marking the part to plot. */
+  template?: string;
+  /** Legacy dot path, still honoured for panels saved before shapes existed. */
+  path?: string;
+}
+
+/**
+ * Extract a plottable number from an MQTT payload. Booleans are mapped to 1/0
+ * so on/off style topics can still be charted; text has no place on an axis and
+ * yields null, which the caller drops rather than plotting as zero.
+ */
+export function parseNumericPayload(
+  payload: string,
+  shape: GraphShape = {},
+): number | null {
+  const { value, dataType } = readValue(
+    shape.template?.trim() || undefined,
+    payload,
+    shape.path?.trim() || undefined,
+  );
+  if (dataType === "number") {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
+  }
+  if (dataType === "boolean") {
+    return value ? 1 : 0;
+  }
+  return null;
+}
+
+/**
+ * The first plottable value anywhere in a payload, for the explorer — which
+ * charts whatever topic is clicked and has no shape to configure. A bare number
+ * is taken as-is; a JSON document is searched by the same ranked paths the
+ * config modal suggests, so `{"value": 21.4, ...}` charts its value rather than
+ * being skipped as text.
+ */
+export function autoNumericPayload(payload: string): number | null {
+  const direct = parseNumericPayload(payload);
+  if (direct !== null) return direct;
+
+  for (const path of suggestPaths(payload)) {
+    const { value, dataType } = extractValue(payload, path);
+    if (dataType === "number") {
+      const num = Number(value);
+      if (Number.isFinite(num)) return num;
+    }
+    if (dataType === "boolean") return value ? 1 : 0;
+  }
+
+  return null;
+}
+
+/**
+ * The read shape a stored graph should open with — the same fallback chain the
+ * gauge uses, so a panel saved with only a dot path is drawn as the shape it
+ * was really describing.
+ */
+export function graphReadTemplate(config: {
+  readTemplate?: string;
+  valueKey?: string;
+}): string {
+  const stored =
+    config.readTemplate !== undefined
+      ? config.readTemplate
+      : templateFromValueKey(config.valueKey);
+  return stored.trim() || VALUE_TOKEN;
+}
+
+interface TrimOptions {
+  maxPoints?: number;
+  windowMs?: number;
+  now?: number;
+}
+
+interface AppendOptions extends TrimOptions {
+  /** Ignore new topics once this many lines are already plotted. */
+  maxSeries?: number;
+}
+
+/** Drop points outside the time window and above the per-series point budget. */
+export function trimPoints(
+  points: GraphPoint[],
+  { maxPoints = 200, windowMs = 0, now = Date.now() }: TrimOptions = {},
+): GraphPoint[] {
+  let next = points;
+  if (windowMs > 0) {
+    const cutoff = now - windowMs;
+    next = next.filter((p) => p.t >= cutoff);
+  }
+  if (maxPoints > 0 && next.length > maxPoints) {
+    next = next.slice(next.length - maxPoints);
+  }
+  return next;
+}
+
+/** Immutably append a point to the matching series, creating it when needed. */
+export function appendPoint(
+  series: GraphSeries[],
+  topic: string,
+  point: GraphPoint,
+  options: AppendOptions = {},
+): GraphSeries[] {
+  const index = series.findIndex((s) => s.topic === topic);
+  if (index === -1) {
+    // A wildcard subscription can match hundreds of topics; keep the chart
+    // readable by only plotting the first few that publish numbers.
+    if (options.maxSeries !== undefined && series.length >= options.maxSeries) {
+      return series;
+    }
+    return [...series, { topic, points: trimPoints([point], options) }];
+  }
+  const target = series[index];
+  // Messages can arrive slightly out of order; keep points sorted by time so
+  // the line never folds back on itself.
+  const points = [...target.points, point];
+  if (points.length > 1 && point.t < points[points.length - 2].t) {
+    points.sort((a, b) => a.t - b.t);
+  }
+  const next = [...series];
+  next[index] = { topic, points: trimPoints(points, options) };
+  return next;
+}
+
+/** Apply the trim options to every series and drop the ones left empty. */
+export function trimSeries(
+  series: GraphSeries[],
+  options: TrimOptions = {},
+): GraphSeries[] {
+  return series
+    .map((s) => ({ topic: s.topic, points: trimPoints(s.points, options) }))
+    .filter((s) => s.points.length > 0);
+}
+
+export function computeBounds(
+  series: GraphSeries[],
+  yMin?: number,
+  yMax?: number,
+): GraphBounds | null {
+  let minT = Infinity;
+  let maxT = -Infinity;
+  let minV = Infinity;
+  let maxV = -Infinity;
+
+  for (const s of series) {
+    for (const p of s.points) {
+      if (p.t < minT) minT = p.t;
+      if (p.t > maxT) maxT = p.t;
+      if (p.v < minV) minV = p.v;
+      if (p.v > maxV) maxV = p.v;
+    }
+  }
+
+  if (!Number.isFinite(minT) || !Number.isFinite(minV)) return null;
+
+  if (Number.isFinite(yMin as number)) minV = yMin as number;
+  if (Number.isFinite(yMax as number)) maxV = yMax as number;
+
+  if (maxV === minV) {
+    // Flat series: open up a symmetric band so the line sits mid-chart.
+    const pad = Math.abs(maxV) > 0 ? Math.abs(maxV) * 0.1 : 1;
+    minV -= pad;
+    maxV += pad;
+  } else if (maxV < minV) {
+    [minV, maxV] = [maxV, minV];
+  }
+
+  return { minT, maxT, minV, maxV };
+}
+
+export function projectX(
+  t: number,
+  bounds: GraphBounds,
+  width: number,
+): number {
+  const span = bounds.maxT - bounds.minT;
+  if (span <= 0) return width;
+  return ((t - bounds.minT) / span) * width;
+}
+
+export function projectY(
+  v: number,
+  bounds: GraphBounds,
+  height: number,
+): number {
+  const span = bounds.maxV - bounds.minV;
+  if (span <= 0) return height / 2;
+  const ratio = (v - bounds.minV) / span;
+  return height - Math.min(Math.max(ratio, 0), 1) * height;
+}
+
+/** Build the SVG path data for one series in the given pixel box. */
+export function buildLinePath(
+  points: GraphPoint[],
+  bounds: GraphBounds,
+  width: number,
+  height: number,
+  curve: CurveType = "linear",
+): string {
+  if (points.length === 0) return "";
+  const coords = points.map((p) => ({
+    x: projectX(p.t, bounds, width),
+    y: projectY(p.v, bounds, height),
+  }));
+
+  if (coords.length === 1) {
+    const { x, y } = coords[0];
+    return `M ${x} ${y} L ${x} ${y}`;
+  }
+
+  if (curve === "step") {
+    let d = `M ${coords[0].x} ${coords[0].y}`;
+    for (let i = 1; i < coords.length; i++) {
+      d += ` L ${coords[i].x} ${coords[i - 1].y} L ${coords[i].x} ${coords[i].y}`;
+    }
+    return d;
+  }
+
+  if (curve === "smooth") {
+    // Monotone cubic (Fritsch-Carlson): a plain Catmull-Rom overshoots on the
+    // spiky, unevenly spaced points a sensor actually produces, drawing loops
+    // and readings the device never sent. This one never leaves the interval
+    // between two neighbouring values.
+    const n = coords.length;
+    const slopes: number[] = [];
+    for (let i = 0; i < n - 1; i++) {
+      const dx = coords[i + 1].x - coords[i].x;
+      slopes.push(dx === 0 ? 0 : (coords[i + 1].y - coords[i].y) / dx);
+    }
+
+    const tangents: number[] = new Array(n);
+    tangents[0] = slopes[0];
+    tangents[n - 1] = slopes[n - 2];
+    for (let i = 1; i < n - 1; i++) {
+      const before = slopes[i - 1];
+      const after = slopes[i];
+      // A local extremum flattens, which is what keeps the curve inside the
+      // data; elsewhere the tangent is the average of the two slopes.
+      tangents[i] = before * after <= 0 ? 0 : (before + after) / 2;
+    }
+
+    // Clamp each tangent so no segment can bulge past its own endpoints.
+    for (let i = 0; i < n - 1; i++) {
+      if (slopes[i] === 0) {
+        tangents[i] = 0;
+        tangents[i + 1] = 0;
+        continue;
+      }
+      const a = tangents[i] / slopes[i];
+      const b = tangents[i + 1] / slopes[i];
+      const h = Math.hypot(a, b);
+      if (h > 3) {
+        tangents[i] = (3 / h) * a * slopes[i];
+        tangents[i + 1] = (3 / h) * b * slopes[i];
+      }
+    }
+
+    let d = `M ${coords[0].x} ${coords[0].y}`;
+    for (let i = 0; i < n - 1; i++) {
+      const dx = coords[i + 1].x - coords[i].x;
+      const c1x = coords[i].x + dx / 3;
+      const c1y = coords[i].y + (tangents[i] * dx) / 3;
+      const c2x = coords[i + 1].x - dx / 3;
+      const c2y = coords[i + 1].y - (tangents[i + 1] * dx) / 3;
+      d += ` C ${c1x} ${c1y}, ${c2x} ${c2y}, ${coords[i + 1].x} ${coords[i + 1].y}`;
+    }
+    return d;
+  }
+
+  return coords.map((c, i) => `${i === 0 ? "M" : "L"} ${c.x} ${c.y}`).join(" ");
+}
+
+/** Close a line path down to the baseline so it can be filled. */
+export function buildAreaPath(
+  linePath: string,
+  points: GraphPoint[],
+  bounds: GraphBounds,
+  width: number,
+  height: number,
+): string {
+  if (!linePath || points.length === 0) return "";
+  const firstX = projectX(points[0].t, bounds, width);
+  const lastX = projectX(points[points.length - 1].t, bounds, width);
+  return `${linePath} L ${lastX} ${height} L ${firstX} ${height} Z`;
+}
+
+/** Evenly spaced value ticks between the bounds, rounded for display. */
+export function valueTicks(bounds: GraphBounds, count = 4): number[] {
+  const ticks: number[] = [];
+  const steps = Math.max(1, count - 1);
+  for (let i = 0; i < count; i++) {
+    ticks.push(bounds.minV + ((bounds.maxV - bounds.minV) * i) / steps);
+  }
+  return ticks;
+}
+
+export function formatValue(value: number): string {
+  if (!Number.isFinite(value)) return "–";
+  const abs = Math.abs(value);
+  if (abs >= 10000) return value.toExponential(1);
+  if (Number.isInteger(value)) return String(value);
+  if (abs >= 100) return value.toFixed(0);
+  if (abs >= 10) return value.toFixed(1);
+  return value.toFixed(2);
+}
+
+export function formatTimeLabel(t: number): string {
+  const d = new Date(t);
+  const pad2 = (n: number) => String(n).padStart(2, "0");
+  return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+}
+
+/** Nearest point (by time) in a series, used for the hover crosshair. */
+export function nearestPoint(
+  points: GraphPoint[],
+  t: number,
+): GraphPoint | null {
+  if (points.length === 0) return null;
+  let best = points[0];
+  let bestDist = Math.abs(best.t - t);
+  for (let i = 1; i < points.length; i++) {
+    const dist = Math.abs(points[i].t - t);
+    if (dist < bestDist) {
+      best = points[i];
+      bestDist = dist;
+    }
+  }
+  return best;
+}

--- a/frontend/src/components/panels/index.ts
+++ b/frontend/src/components/panels/index.ts
@@ -2,6 +2,7 @@ import { registerPanel } from "./registry";
 import {
   gaugePanelDefinition,
   logPanelDefinition,
+  graphPanelDefinition,
   brokerStatsPanelDefinition,
   buttonPanelDefinition,
   inputPanelDefinition,
@@ -16,6 +17,7 @@ import {
 // Register all built-in panels
 registerPanel(gaugePanelDefinition);
 registerPanel(logPanelDefinition);
+registerPanel(graphPanelDefinition);
 registerPanel(brokerStatsPanelDefinition);
 registerPanel(buttonPanelDefinition);
 registerPanel(inputPanelDefinition);

--- a/frontend/src/pages/ExplorerPage.tsx
+++ b/frontend/src/pages/ExplorerPage.tsx
@@ -5,6 +5,7 @@ import { useBrokerStatuses } from "../hooks/useBrokers";
 import { useWebSocket } from "../hooks/useWebSocket";
 import TopicTree from "../components/explorer/TopicTree";
 import LogPanel from "../components/panels/LogPanel";
+import GraphPanel from "../components/panels/GraphPanel";
 import ExplorerPublishPanel from "../components/explorer/ExplorerPublishPanel";
 import { topicMatchesFilter } from "../components/explorer/topicFilterUtils";
 
@@ -64,6 +65,8 @@ export default function ExplorerPage() {
   );
   const [liveMessages, setLiveMessages] = useState<WSMessage[]>([]);
   const [showSysTopic, setShowSysTopic] = useState(false);
+  const [showGraph, setShowGraph] = useState(false);
+  const [graphWindowSeconds, setGraphWindowSeconds] = useState(900);
   const [showExactTopicOnly, setShowExactTopicOnly] = useState(false);
   const [defaultExpanded, setDefaultExpanded] = useState(false);
   const [expandCollapseVersion, setExpandCollapseVersion] = useState(0);
@@ -314,10 +317,14 @@ export default function ExplorerPage() {
             ? `${filteredTopics.length} of ${displayedTopics.length} topics`
             : `${displayedTopics.length} topics captured`}
         </span>
+        {/* tooltip-start top-aligns these tips so they grow downward. Centred,
+            a multi-line tip on this thin row reaches up into the sticky navbar
+            (z-40 in Layout.tsx) and is painted over; raising the toggles above
+            it instead would put them in front of the broker flyout. */}
         <div className="ml-auto flex items-center gap-4">
           <label className="label cursor-pointer gap-2 p-0">
             <div
-              className="tooltip tooltip-left"
+              className="tooltip tooltip-left tooltip-start"
               data-tip="When enabled, clicking a parent topic only shows messages published directly to that exact topic instead of including all child topics (topic/#)."
             >
               <span className="label-text text-xs">Show exact topic only</span>
@@ -331,7 +338,21 @@ export default function ExplorerPage() {
           </label>
           <label className="label cursor-pointer gap-2 p-0">
             <div
-              className="tooltip tooltip-left"
+              className="tooltip tooltip-left tooltip-start"
+              data-tip="Plot the selected topic over time. Bare numbers are charted directly; for JSON payloads the first numeric field is picked automatically. Messages with nothing numeric in them are skipped."
+            >
+              <span className="label-text text-xs">Show graph</span>
+            </div>
+            <input
+              type="checkbox"
+              className="toggle toggle-xs toggle-accent"
+              checked={showGraph}
+              onChange={(e) => setShowGraph(e.target.checked)}
+            />
+          </label>
+          <label className="label cursor-pointer gap-2 p-0">
+            <div
+              className="tooltip tooltip-left tooltip-start"
               data-tip="Show $SYS broker system topics in the tree. If you have not enabled 'Save $SYS topics in history' in settings, these topics will only be visible here when they are published by the broker, and will not be saved to history."
             >
               <span className="label-text text-xs">Show $SYS</span>
@@ -466,6 +487,46 @@ export default function ExplorerPage() {
                   </div>
                 ))}
               </div>
+              {showGraph && (
+                <section className="shrink-0 rounded-lg border border-base-300 bg-base-100">
+                  <div className="flex items-center gap-2 px-3 py-1.5 border-b border-base-300">
+                    <span className="text-xs font-semibold text-base-content/50 uppercase tracking-wider">
+                      Graph
+                    </span>
+                    <select
+                      className="select select-bordered select-xs ml-auto"
+                      value={graphWindowSeconds}
+                      onChange={(e) =>
+                        setGraphWindowSeconds(Number(e.target.value))
+                      }
+                    >
+                      <option value={300}>Last 5 minutes</option>
+                      <option value={900}>Last 15 minutes</option>
+                      <option value={3600}>Last hour</option>
+                      <option value={21600}>Last 6 hours</option>
+                      <option value={86400}>Last 24 hours</option>
+                      <option value={0}>All history</option>
+                    </select>
+                  </div>
+                  <div className="h-48 p-2">
+                    <GraphPanel
+                      key={`graph:${effectiveBrokerId}:${selectedTopic}:${graphWindowSeconds}`}
+                      panelId={`${panelId}-graph`}
+                      brokerId={effectiveBrokerId}
+                      compact
+                      autoValue
+                      config={{
+                        topics: selectedTopic,
+                        maxPoints: 500,
+                        timeWindowSeconds: graphWindowSeconds,
+                        curve: "linear",
+                        showArea: true,
+                        showLegend: true,
+                      }}
+                    />
+                  </div>
+                </section>
+              )}
               <div className="flex-1 overflow-hidden min-h-0">
                 <LogPanel
                   key={`${effectiveBrokerId}:${selectedTopic}`}


### PR DESCRIPTION
Adds a **Graph** panel — numeric payloads plotted over time — plus the explorer and dev-environment work that came out of building it.

## Graph panel

One line per topic matched by the panel's topic list, so a wildcard charts everything it matches up to a series cap. Values are read through the same payload shape the gauge and toggle use, so a bare `21.4`, a JSON `{"value": 21.4}` and a templated document all work from one config. Booleans plot as 1 and 0 so on/off topics can be charted; anything non-numeric is skipped rather than plotted as zero, and the panel says so explicitly instead of showing the same spinner as a topic that is merely quiet.

The series is seeded from stored history on mount and then extended live over the websocket, trimmed by both a point cap and a time window. Options: three curve types, area fill, points, legend, fixed or automatic Y axis, time window, and a hover crosshair with a nearest-point readout.

**No charting dependency.** The frontend has none today, and the ~370 lines of `graphUtils.ts` a library would replace are the easy part — the parts that matter here (streaming appends, a scrolling window, resizing inside `react-grid-layout`, daisyUI theme colours) are the parts a chart library makes harder. If the panel later needs brushing, multiple axes or stacked variants, that trade flips and `graphUtils.ts` is the seam to cut at.

The explorer charts whatever topic is selected with no shape to configure, so it falls back to searching the payload by the same ranked paths the config modal suggests.

## Explorer fixes

- Header-bar tooltips were painted over by the sticky navbar. daisyUI gives the bubble `z-index: 2` on a wrapper with no z-index of its own, so the navbar's `z-40` won; `tooltip-start` top-aligns them so they grow downward instead. (Raising the toggles above the navbar was the other option, but that puts them in front of the broker flyout, which is nested inside the navbar's stacking context and cannot rise above it.)
- "Show graph" defaults off, like the two toggles beside it.
- The "cannot publish to wildcard topic" notice remembered its dismissal in component state keyed by topic, so it returned on every reload and every different wildcard topic. Now in `localStorage`, and global — the reason does not change between `sensors/#` and `home/+/state`.

## Dev environment

**The container refused to start over `frontend/node_modules`,** on a directory it was recreating itself: the host editor writes `.tmp/*.tsbuildinfo` there via tsconfig's `tsBuildInfoFile`, and Vite writes `node_modules/.vite-temp` from inside the container regardless of `VITE_CACHE_DIR`. Compose now masks the path with an empty tmpfs — the host's copy is invisible, Vite's temp writes go to RAM, the worktree stays clean. The guard warns instead of exiting. The `/node_modules` design from #151 is untouched.

**The worker now answers the panels that publish.** Toggle, slider, button, input and cron all send commands and nothing was listening, so they had nowhere to publish and never read a state back. The worker simulates the devices behind them — command in, retained state out, and every command echoed to `demo/events`:

| Command topic | Accepted | State topic (retained) |
| --- | --- | --- |
| `demo/lamp/set` | `ON`/`OFF` bare or `{"state": "ON"}` | `demo/lamp/state` |
| `demo/fan/set` | number, bare or wrapped | `demo/fan/state` |
| `demo/thermostat/set` | number, bare or wrapped | `demo/thermostat/state` |
| `demo/actions/+`, `test/command`, `test/heartbeat` | anything | `demo/events` |

Telemetry gained a `demo/` namespace publishing every series on every tick at 1s instead of 5s — the existing simulator picks one random room and metric per round, leaving any single topic with a point every few minutes, far too sparse to draw a line from. Series are a bounded random walk, one is a bare number, and one slips in occasional non-numeric messages so the graph's skip path has a subject. The thermostat's measured value chases its setpoint, so moving the slider draws a curve.

**`config.json` seeds three dashboards covering all 12 panel types** — Monitors, Controls, Layout — each group followed by a debug log on the exact topics its panels read, and for the controls one log for commands out and one for the worker's replies. Every non-visual panel pins its header meta. The stale separator config (`thickness`/`color`, no longer in `SeparatorConfig`) is gone.

## Testing

- `tsc -b`, eslint, prettier, `npm test` (200 tests) and `go vet` / `go test ./...` all clean.
- Command round-trip exercised live against the dev stack: published exactly what each control panel sends — bare `ON`, `{"state":"OFF","src":"dashboard"}`, bare `75`, `{"setpoint":26.5}`, button and input payloads — and confirmed correct retained state plus a `demo/events` line for each.
- Graph series confirmed at one message per second per topic; thermostat observed climbing toward its setpoint.
- All three dashboards seeded (12/19/8 panels, brokers bound, cron jobs registered including the disabled one); `config.json` script-checked for grid overlaps, column overflow and unknown panel types.

Note: dashboards are only seeded when one of that name has no panels, so an existing dev database keeps its old **Dev Showcase** alongside the new ones — delete it in the UI, or delete `backend/data/mqtt-dashboard.db` to start fresh.

https://claude.ai/code/session_01EeuhpZDqbtpcowqhJSVAgV