### PR TITLE
chore(demo): expose mosquitto on dokploy-network for standalone apps

### DIFF
--- a/docker/demo/docker-compose.yml
+++ b/docker/demo/docker-compose.yml
@@ -12,6 +12,13 @@ services:
     restart: unless-stopped
     volumes:
       - ./mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+    networks:
+      # Keep the compose-internal network so mqtt-worker still reaches it as "mosquitto".
+      default: {}
+      # Also attach to Dokploy's shared overlay so standalone/preview apps can reach it.
+      dokploy-network:
+        aliases:
+          - mqtt-demo-broker
 
   mqtt-worker:
     build:
@@ -31,3 +38,7 @@ services:
 
 volumes:
   data_volume:
+
+networks:
+  dokploy-network:
+    external: true


### PR DESCRIPTION
## What

Attaches the demo `mosquitto` broker to Dokploy's shared overlay network (`dokploy-network`) with a stable alias `mqtt-demo-broker`.

## Why

Preview deployments aren't available for Docker Compose in Dokploy, so the dashboard is now also deployed as a standalone **Application** (GitHub source, Dockerfile build) with preview deployments enabled. Dokploy Applications run as **Swarm services**, which cannot join the compose-internal bridge network where `mosquitto` lives. Putting the broker on `dokploy-network` lets the standalone and per-PR preview dashboards reach it on port 1883.

- `mqtt-worker` is unchanged — it still reaches the broker as `mosquitto` over the compose `default` network.
- Standalone/preview apps connect via the seeded `config.json` pointing at `mqtt-demo-broker:1883`.
- Additive only; no ports exposed publicly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)